### PR TITLE
feature: handle editor load errors gracefully

### DIFF
--- a/packages/editor-worker/src/parts/DiffItems/DiffItems.ts
+++ b/packages/editor-worker/src/parts/DiffItems/DiffItems.ts
@@ -6,6 +6,7 @@ export const isEqual = (oldState: EditorState, newState: EditorState): boolean =
     oldState.diagnostics === newState.diagnostics &&
     oldState.highlightedLine === newState.highlightedLine &&
     oldState.lineNumbers === newState.lineNumbers &&
+    oldState.loadError === newState.loadError &&
     oldState.textInfos === newState.textInfos &&
     oldState.differences === newState.differences &&
     oldState.initial === newState.initial &&

--- a/packages/editor-worker/src/parts/GetEditorVirtualDom/GetEditorVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorVirtualDom/GetEditorVirtualDom.ts
@@ -3,6 +3,7 @@ import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEven
 import * as GetEditorContentVirtualDom from '../GetEditorContentVirtualDom/GetEditorContentVirtualDom.ts'
 import * as GetEditorGutterLayerVirtualDom from '../GetEditorGutterLayerVirtualDom/GetEditorGutterLayerVirtualDom.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
+import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
 interface EditorVirtualDomOptions {
   readonly cursorInfos?: readonly any[]
@@ -14,6 +15,7 @@ interface EditorVirtualDomOptions {
   readonly height?: number
   readonly highlightedLine?: number
   readonly lineNumbers?: boolean
+  readonly loadError?: string
   readonly scrollBarDiagnostics?: readonly any[]
   readonly scrollBarHeight?: number
   readonly selectionInfos?: readonly any[]
@@ -28,10 +30,32 @@ export const getEditorVirtualDom = ({
   gutterInfos = [],
   highlightedLine = -1,
   lineNumbers = true,
+  loadError = '',
   scrollBarDiagnostics = [],
   selectionInfos = [],
   textInfos,
 }: EditorVirtualDomOptions): readonly VirtualDomNode[] => {
+  if (loadError) {
+    return [
+      {
+        childCount: 2,
+        className: 'Viewlet TextEditorError',
+        role: 'code',
+        type: VirtualDomElements.Div,
+      },
+      {
+        childCount: 0,
+        className: 'EditorTextIcon EditorTextIconError MaskIcon MaskIconError',
+        type: VirtualDomElements.Div,
+      },
+      {
+        childCount: 1,
+        className: 'TextEditorErrorMessage',
+        type: VirtualDomElements.Div,
+      },
+      text(loadError),
+    ]
+  }
   const gutterDom = lineNumbers ? GetEditorGutterLayerVirtualDom.getEditorGutterVirtualDom(gutterInfos) : []
   return [
     {

--- a/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
@@ -26,6 +26,13 @@ const getTokenizePath = (languages: readonly any[], languageId: string): string 
   return ''
 }
 
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}
+
 export const loadContent = async (state: EditorState, savedState: unknown) => {
   const { assetDir, height, id, platform, uri, width, x, y } = state
   const {
@@ -68,11 +75,26 @@ export const loadContent = async (state: EditorState, savedState: unknown) => {
     languageId: computedLanguageId,
     letterSpacing,
     lineNumbers,
+    loadError: '',
     rowHeight,
     tabSize,
     tokenizerId: newTokenizerId,
   }
-  const content = await RendererWorker.readFile(uri)
+  let content = ''
+  try {
+    content = await RendererWorker.readFile(uri)
+  } catch (error) {
+    const newEditor1 = Editor.setBounds(newEditor0, x, y, width, height, 9)
+    return {
+      ...newEditor1,
+      differences: [],
+      focus: WhenExpression.FocusEditorText,
+      focused: true,
+      initial: false,
+      loadError: getErrorMessage(error),
+      textInfos: [],
+    }
+  }
 
   // TODO avoid creating intermediate editors here
   const newEditor1 = Editor.setBounds(newEditor0, x, y, width, height, 9)

--- a/packages/editor-worker/src/parts/State/State.ts
+++ b/packages/editor-worker/src/parts/State/State.ts
@@ -46,6 +46,7 @@ export interface EditorState {
   readonly lineCache: readonly any[]
   readonly lineNumbers: boolean
   readonly lines: readonly string[]
+  readonly loadError?: string
   readonly longestLineWidth: number
   readonly maxLineY: number
   readonly minimumSliderSize: number

--- a/packages/editor-worker/test/GetEditorVirtualDom.test.ts
+++ b/packages/editor-worker/test/GetEditorVirtualDom.test.ts
@@ -194,3 +194,31 @@ test('getEditorVirtualDom - line numbers disabled', () => {
   })
   expect(dom.some((node) => node.className === 'Gutter')).toBe(false)
 })
+
+test('getEditorVirtualDom - load error', () => {
+  const dom = GetEditorVirtualDom.getEditorVirtualDom({
+    differences: [],
+    loadError: 'Failed to read file',
+    textInfos: [],
+  })
+
+  expect(dom).toEqual([
+    {
+      childCount: 2,
+      className: 'Viewlet TextEditorError',
+      role: 'code',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 0,
+      className: 'EditorTextIcon EditorTextIconError MaskIcon MaskIconError',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 1,
+      className: 'TextEditorErrorMessage',
+      type: VirtualDomElements.Div,
+    },
+    text('Failed to read file'),
+  ])
+})

--- a/packages/editor-worker/test/LoadContent.test.ts
+++ b/packages/editor-worker/test/LoadContent.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const getEditorPreferencesMock: any = jest.fn()
+const getLanguagesMock: any = jest.fn()
+const getTokenizerMock: any = jest.fn()
+const loadTokenizerMock: any = jest.fn()
+const measureCharacterWidthMock: any = jest.fn()
+const readFileMock: any = jest.fn()
+
+jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
+  ExtensionHost: {
+    invoke: jest.fn(),
+    invokeAndTransfer: jest.fn(),
+    set: jest.fn(),
+  },
+  ExtensionManagementWorker: {
+    invoke: jest.fn(),
+  },
+  RendererWorker: {
+    getPreference: jest.fn(),
+    invoke: jest.fn(),
+    readFile: readFileMock,
+  },
+  SyntaxHighlightingWorker: {
+    invoke: jest.fn(),
+    invokeAndTransfer: jest.fn(),
+    set: jest.fn(),
+  },
+  TextMeasurementWorker: {
+    invoke: jest.fn(),
+    invokeAndTransfer: jest.fn(),
+    set: jest.fn(),
+  },
+}))
+
+jest.unstable_mockModule('../src/parts/GetEditorPreferences/GetEditorPreferences.ts', () => ({
+  getEditorPreferences: getEditorPreferencesMock,
+}))
+
+jest.unstable_mockModule('../src/parts/GetLanguages/GetLanguages.ts', () => ({
+  getLanguages: getLanguagesMock,
+}))
+
+jest.unstable_mockModule('../src/parts/MeasureCharacterWidth/MeasureCharacterWidth.ts', () => ({
+  measureCharacterWidth: measureCharacterWidthMock,
+}))
+
+jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.ts', () => ({
+  getTokenizer: getTokenizerMock,
+  loadTokenizer: loadTokenizerMock,
+}))
+
+const LoadContent = await import('../src/parts/LoadContent/LoadContent.ts')
+
+const createState = () =>
+  ({
+    assetDir: '/test/assets',
+    charWidth: 8,
+    columnWidth: 0,
+    completionTriggerCharacters: [],
+    cursorWidth: 2,
+    deltaY: 0,
+    differences: [],
+    embeds: [],
+    focused: false,
+    fontFamily: 'monospace',
+    fontSize: 14,
+    fontWeight: 400,
+    height: 200,
+    highlightedLine: -1,
+    id: 1,
+    initial: true,
+    isMonospaceFont: false,
+    itemHeight: 20,
+    languageId: '',
+    letterSpacing: 0,
+    lineNumbers: true,
+    lines: [],
+    maxLineY: 0,
+    minimumSliderSize: 20,
+    minLineY: 0,
+    numberOfVisibleLines: 0,
+    platform: 1,
+    rowHeight: 20,
+    selections: new Uint32Array(),
+    tabSize: 2,
+    textInfos: [],
+    tokenizerId: 0,
+    uid: 1,
+    uri: 'file:///test.txt',
+    width: 300,
+    x: 0,
+    y: 0,
+  }) as any
+
+beforeEach(() => {
+  getEditorPreferencesMock.mockReset()
+  getLanguagesMock.mockReset()
+  getTokenizerMock.mockReset()
+  loadTokenizerMock.mockReset()
+  measureCharacterWidthMock.mockReset()
+  readFileMock.mockReset()
+
+  getEditorPreferencesMock.mockResolvedValue({
+    completionTriggerCharacters: [],
+    diagnosticsEnabled: false,
+    fontFamily: 'monospace',
+    fontSize: 14,
+    fontWeight: 400,
+    isAutoClosingBracketsEnabled: false,
+    isAutoClosingQuotesEnabled: false,
+    isAutoClosingTagsEnabled: false,
+    isQuickSuggestionsEnabled: false,
+    letterSpacing: 0,
+    lineNumbers: true,
+    rowHeight: 20,
+    tabSize: 2,
+  })
+  getLanguagesMock.mockResolvedValue([{ extensions: ['.txt'], id: 'plaintext', tokenize: '' }])
+  getTokenizerMock.mockReturnValue({})
+  measureCharacterWidthMock.mockResolvedValue(8)
+})
+
+test('loadContent returns error state when reading file fails', async () => {
+  readFileMock.mockRejectedValue(new Error('Failed to read file'))
+
+  const result = await LoadContent.loadContent(createState(), undefined)
+
+  expect(result.loadError).toBe('Failed to read file')
+  expect(result.focused).toBe(true)
+  expect(result.initial).toBe(false)
+  expect(result.textInfos).toEqual([])
+  expect(result.height).toBe(200)
+  expect(readFileMock).toHaveBeenCalledWith('file:///test.txt')
+})


### PR DESCRIPTION
## Summary
- catch file read failures during editor load and keep the editor viewlet renderable
- store the load failure on editor state and render the existing text-editor error UI
- add regression coverage for failed `readFile` and error-state virtual DOM

## Local Checks
- `npm run type-check`
- `npm run lint` (passes with existing skipped-test warnings)
- `npm test`
- `npm test -- --coverage=false --runTestsByPath test/GetEditorVirtualDom.test.ts test/LoadContent.test.ts`

Heavy e2e coverage left to CI.