### PR TITLE
fix: show save error dialog in electron

### DIFF
--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandSave.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandSave.ts
@@ -1,3 +1,4 @@
+import { PlatformType } from '@lvce-editor/constants'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.ts'
 import * as TextDocument from '../TextDocument/TextDocument.ts'
 import { VError } from '../VError/VError.ts'
@@ -5,6 +6,7 @@ import { getNewEditor } from './EditorCommandSave/getNewEditor.ts'
 import { isUntitledFile } from './EditorCommandSave/isUntitledFile.ts'
 import { saveNormalFile } from './EditorCommandSave/saveNormalFile.ts'
 import { saveUntitledFile } from './EditorCommandSave/saveUntitledFile.ts'
+import { showSaveErrorDialog } from './EditorCommandSave/showSaveErrorDialog.ts'
 
 export const save = async (editor: any): Promise<any> => {
   try {
@@ -24,6 +26,13 @@ export const save = async (editor: any): Promise<any> => {
     // @ts-ignore
     const betterError = new VError(error, `Failed to save file "${editor.uri}"`)
     await ErrorHandling.handleError(betterError)
+    if (editor.platform === PlatformType.Electron) {
+      try {
+        await showSaveErrorDialog(betterError)
+      } catch (dialogError) {
+        await ErrorHandling.handleError(dialogError)
+      }
+    }
     return editor
   }
 }

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandSave/showSaveErrorDialog.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandSave/showSaveErrorDialog.ts
@@ -1,0 +1,12 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const showSaveErrorDialog = async (error: Error): Promise<void> => {
+  await RendererWorker.invoke('ElectronDialog.showMessageBox', {
+    buttons: ['OK'],
+    defaultId: 0,
+    detail: error.message,
+    message: 'Saving the file failed.',
+    title: 'Failed to Save File',
+    type: 'error',
+  })
+}

--- a/packages/editor-worker/test/Save.test.ts
+++ b/packages/editor-worker/test/Save.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { PlatformType } from '@lvce-editor/constants'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as EditorCommandSave from '../src/parts/EditorCommand/EditorCommandSave.ts'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('save - shows electron message box when saving file fails', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ElectronDialog.showMessageBox': async () => {
+      return 0
+    },
+    'FileSystem.writeFile': async () => {
+      throw new Error('EACCES: permission denied')
+    },
+  })
+  const editor = {
+    lines: ['hello world'],
+    modified: true,
+    platform: PlatformType.Electron,
+    uri: 'file:///tmp/read-only.txt',
+  }
+
+  const result = await EditorCommandSave.save(editor)
+
+  expect(result).toBe(editor)
+  expect(mockRpc.invocations).toEqual([
+    ['FileSystem.writeFile', 'file:///tmp/read-only.txt', 'hello world'],
+    [
+      'ElectronDialog.showMessageBox',
+      {
+        buttons: ['OK'],
+        defaultId: 0,
+        detail: 'Failed to save file "file:///tmp/read-only.txt": EACCES: permission denied',
+        message: 'Saving the file failed.',
+        title: 'Failed to Save File',
+        type: 'error',
+      },
+    ],
+  ])
+})
+
+test('save - does not show electron message box when saving file fails outside electron', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.writeFile': async () => {
+      throw new Error('EACCES: permission denied')
+    },
+  })
+  const editor = {
+    lines: ['hello world'],
+    modified: true,
+    platform: PlatformType.Web,
+    uri: 'file:///tmp/read-only.txt',
+  }
+
+  const result = await EditorCommandSave.save(editor)
+
+  expect(result).toBe(editor)
+  expect(mockRpc.invocations).toEqual([['FileSystem.writeFile', 'file:///tmp/read-only.txt', 'hello world']])
+})


### PR DESCRIPTION
Adds an Electron message box when saving a file fails, while keeping the existing console error logging.

Also adds coverage for Electron and non-Electron save failure behavior.