### PR TITLE
fix: expose editor resize command

### DIFF
--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -160,6 +160,7 @@ import * as RegisterListener from '../RegisterListener/RegisterListener.ts'
 import { render2 } from '../Render2/Render2.ts'
 import * as RenderEditor from '../RenderEditor/RenderEditor.ts'
 import * as RenderEventListeners from '../RenderEventListeners/RenderEventListeners.ts'
+import * as Resize from '../Resize/Resize.ts'
 import { saveState } from '../SaveState/SaveState.ts'
 import * as SendMessagePortToExtensionHostWorker from '../SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.ts'
 import { sendMessagePortToExtensionManagementWorker } from '../SendMessagePortToExtensionManagementWorker/SendMessagePortToExtensionManagementWorker.ts'
@@ -311,6 +312,7 @@ export const commandMap = {
   'Editor.renderEventListeners': RenderEventListeners.renderEventListeners,
   'Editor.replaceRange': wrapCommand(ReplaceRange.replaceRange),
   'Editor.rerender': wrapCommand(EditorRerender.rerender),
+  'Editor.resize': wrapCommand(Resize.resize),
   'Editor.save': wrapCommand(Save.save),
   'Editor.saveState': wrapGetter(saveState),
   'Editor.selectAll': wrapCommand(SelectAll.selectAll),

--- a/packages/editor-worker/test/Resize.test.ts
+++ b/packages/editor-worker/test/Resize.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@jest/globals'
+import { commandMap } from '../src/parts/CommandMap/CommandMap.ts'
 import * as Resize from '../src/parts/Resize/Resize.ts'
 
 test('resize updates bounds and visible lines', () => {
@@ -79,4 +80,8 @@ test('resize clamps scroll position when height increases', () => {
     x: 1,
     y: 2,
   })
+})
+
+test('resize is available as an editor command', () => {
+  expect(commandMap['Editor.resize']).toBeDefined()
 })


### PR DESCRIPTION
Adds an Editor.resize command so editor clients can update worker viewport state when the editor bounds change.