### PR TITLE
fix: preserve fractional editor ids

### DIFF
--- a/packages/editor-worker/src/parts/GetProblems/GetProblems.ts
+++ b/packages/editor-worker/src/parts/GetProblems/GetProblems.ts
@@ -11,7 +11,7 @@ export const getProblems = async (): Promise<readonly Problem[]> => {
   // or query the diagnostics for the problems view directtly from the extension host worker
   const keys = Editors.getKeys()
   const editors = keys.map((key) => {
-    const numericKey = parseInt(key)
+    const numericKey = Number(key)
     const editor = Editors.get(numericKey)
     return editor
   })

--- a/packages/editor-worker/test/GetProblems.test.ts
+++ b/packages/editor-worker/test/GetProblems.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@jest/globals'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import * as EditorStates from '../src/parts/EditorStates/EditorStates.ts'
+import { getProblems } from '../src/parts/GetProblems/GetProblems.ts'
+
+test('getProblems preserves fractional editor ids', async () => {
+  const editorId = 0.123456
+  const editor = {
+    id: editorId,
+    languageId: 'javascript',
+    lines: ['const value = 1'],
+    uid: editorId,
+    uri: '/test.js',
+  }
+  const diagnostics = [
+    {
+      message: 'test problem',
+      uri: editor.uri,
+    },
+  ]
+  EditorStates.set(editorId, editor as any, editor as any)
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeDiagnosticProvider': () => diagnostics,
+  })
+
+  await expect(getProblems()).resolves.toEqual(diagnostics)
+  expect(mockRpc.invocations).toEqual([
+    [
+      'Extensions.executeDiagnosticProvider',
+      {
+        documentId: editorId,
+        languageId: editor.languageId,
+        text: editor.lines[0],
+        uri: editor.uri,
+      },
+    ],
+  ])
+})


### PR DESCRIPTION
Fix Problems view diagnostic collection by preserving fractional editor UIDs during state lookup. Adds regression coverage for fractional IDs.