### PR TITLE
fix: refocus editor when selecting

### DIFF
--- a/packages/editor-worker/src/parts/DiffFocus/DiffFocus.ts
+++ b/packages/editor-worker/src/parts/DiffFocus/DiffFocus.ts
@@ -4,5 +4,8 @@ export const isEqual = (oldState: EditorState, newState: EditorState): boolean =
   if (!newState.focused) {
     return true
   }
+  if (!oldState.isSelecting && newState.isSelecting) {
+    return false
+  }
   return oldState.focused === newState.focused && oldState.focus === newState.focus
 }

--- a/packages/editor-worker/test/DiffFocus.test.ts
+++ b/packages/editor-worker/test/DiffFocus.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@jest/globals'
+import * as DiffFocus from '../src/parts/DiffFocus/DiffFocus.ts'
+
+test('isEqual - returns false when a focused editor starts selecting', () => {
+  const oldState = {
+    focus: 1,
+    focused: true,
+    isSelecting: false,
+  }
+  const newState = {
+    ...oldState,
+    isSelecting: true,
+  }
+
+  expect(DiffFocus.isEqual(oldState as any, newState as any)).toBe(false)
+})
+
+test('isEqual - returns true while selection continues', () => {
+  const state = {
+    focus: 1,
+    focused: true,
+    isSelecting: true,
+  }
+
+  expect(DiffFocus.isEqual(state as any, state as any)).toBe(true)
+})
+
+test('isEqual - returns true when the editor becomes unfocused', () => {
+  const oldState = {
+    focus: 1,
+    focused: true,
+    isSelecting: false,
+  }
+  const newState = {
+    ...oldState,
+    focused: false,
+  }
+
+  expect(DiffFocus.isEqual(oldState as any, newState as any)).toBe(true)
+})


### PR DESCRIPTION
Ensure starting a mouse selection reissues the editor textarea focus command, allowing the editor to recover when logical focus is stale but the DOM active element is document.body. Adds focused regression coverage for the focus diff behavior.