### PR TITLE
fix: scope scrollbar styles per editor

### DIFF
--- a/packages/e2e/src/editor.scrollbar-switch-tabs.ts
+++ b/packages/e2e/src/editor.scrollbar-switch-tabs.ts
@@ -17,12 +17,12 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main, Workspace 
 
   const editorRows = Locator('.EditorRows')
   const verticalThumb = Locator('.ScrollBarThumbVertical')
-  await expect(verticalThumb).toBeHidden()
+  await expect(verticalThumb).toHaveCSS('height', '0px')
 
   await Main.openUri(longFilePath)
   await expect(verticalThumb).toBeVisible()
 
   await Main.selectTab(0, 0)
   await expect(editorRows).toHaveText('short')
-  await expect(verticalThumb).toBeHidden()
+  await expect(verticalThumb).toHaveCSS('height', '0px')
 }

--- a/packages/e2e/src/editor.scrollbar-switch-tabs.ts
+++ b/packages/e2e/src/editor.scrollbar-switch-tabs.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.scrollbar-switch-tabs'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const shortFilePath = `${tmpDir}/short.txt`
+  const longFilePath = `${tmpDir}/long.txt`
+  const longContent = Array.from({ length: 200 }, (_, index) => `line ${index}`).join('\n')
+
+  await FileSystem.writeFile(shortFilePath, 'short')
+  await FileSystem.writeFile(longFilePath, longContent)
+  await Workspace.setPath(tmpDir)
+  await Main.closeAllEditors()
+
+  await Main.openUri(shortFilePath)
+
+  const editorRows = Locator('.EditorRows')
+  const verticalThumb = Locator('.ScrollBarThumbVertical')
+  await expect(verticalThumb).toBeHidden()
+
+  await Main.openUri(longFilePath)
+  await expect(verticalThumb).toBeVisible()
+
+  await Main.selectTab(0, 0)
+  await expect(editorRows).toHaveText('short')
+  await expect(verticalThumb).toBeHidden()
+}

--- a/packages/editor-worker/src/parts/GetCss/GetCss.ts
+++ b/packages/editor-worker/src/parts/GetCss/GetCss.ts
@@ -1,20 +1,28 @@
-export const getCss = (rowHeight: number, scrollBarHeight: number, scrollBarTop: number, scrollBarWidth: number, scrollBarLeft: number): string => {
-  return `.Editor {
+export const getCss = (
+  uid: number,
+  rowHeight: number,
+  scrollBarHeight: number,
+  scrollBarTop: number,
+  scrollBarWidth: number,
+  scrollBarLeft: number,
+): string => {
+  const editorSelector = `.Editor[data-uid="${uid}"]`
+  return `${editorSelector} {
   --EditorRowHeight: ${rowHeight}px;
   --ScrollBarHeight: ${scrollBarHeight}px;
   --ScrollBarTop: ${scrollBarTop}px;
   --ScrollBarWidth: ${scrollBarWidth}px;
   --ScrollBarLeft: ${scrollBarLeft}px;
 }
-.Editor .EditorRow {
+${editorSelector} .EditorRow {
   height: var(--EditorRowHeight);
   line-height: var(--EditorRowHeight);
 }
-.Editor .ScrollBarThumbVertical {
+${editorSelector} .ScrollBarThumbVertical {
   height: var(--ScrollBarHeight);
   translate: 0px var(--ScrollBarTop);
 }
-.Editor .ScrollBarThumbHorizontal {
+${editorSelector} .ScrollBarThumbHorizontal {
   width: var(--ScrollBarWidth);
   translate: var(--ScrollBarLeft) 0px;
 }

--- a/packages/editor-worker/src/parts/GetEditorVirtualDom/GetEditorVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorVirtualDom/GetEditorVirtualDom.ts
@@ -21,6 +21,7 @@ interface EditorVirtualDomOptions {
   readonly selectionInfos?: readonly any[]
   readonly selections?: any
   readonly textInfos: readonly any[]
+  readonly uid: number
 }
 
 export const getEditorVirtualDom = ({
@@ -34,12 +35,14 @@ export const getEditorVirtualDom = ({
   scrollBarDiagnostics = [],
   selectionInfos = [],
   textInfos,
+  uid,
 }: EditorVirtualDomOptions): readonly VirtualDomNode[] => {
   if (loadError) {
     return [
       {
         childCount: 2,
         className: 'Viewlet TextEditorError',
+        'data-uid': uid,
         role: 'code',
         type: VirtualDomElements.Div,
       },
@@ -61,6 +64,7 @@ export const getEditorVirtualDom = ({
     {
       childCount: lineNumbers ? 2 : 1,
       className: 'Viewlet Editor',
+      'data-uid': uid,
       onContextMenu: DomEventListenerFunctions.HandleContextMenu,
       role: 'code',
       type: VirtualDomElements.Div,

--- a/packages/editor-worker/src/parts/RenderCss/RenderCss.ts
+++ b/packages/editor-worker/src/parts/RenderCss/RenderCss.ts
@@ -16,6 +16,6 @@ export const renderCss = (oldState: EditorState, newState: EditorState): readonl
   const scrollBarTop = ScrollBarFunctions.getScrollBarY(deltaY, finalDeltaY, height, scrollBarHeight)
   const scrollBarWidth = ScrollBarFunctions.getScrollBarSize(width, longestLineWidth, minimumSliderSize)
   const scrollBarLeft = getScrollBarLeft(deltaX, longestLineWidth, width)
-  const css = getCss(rowHeight, scrollBarHeight, scrollBarTop, scrollBarWidth, scrollBarLeft)
+  const css = getCss(uid, rowHeight, scrollBarHeight, scrollBarTop, scrollBarWidth, scrollBarLeft)
   return [ViewletCommand.SetCss, uid, css]
 }

--- a/packages/editor-worker/test/GetCss.test.ts
+++ b/packages/editor-worker/test/GetCss.test.ts
@@ -2,22 +2,22 @@ import { expect, test } from '@jest/globals'
 import { getCss } from '../src/parts/GetCss/GetCss.ts'
 
 test('getCss', () => {
-  expect(getCss(20, 24, 8, 40, 20)).toBe(`.Editor {
+  expect(getCss(42, 20, 24, 8, 40, 20)).toBe(`.Editor[data-uid="42"] {
   --EditorRowHeight: 20px;
   --ScrollBarHeight: 24px;
   --ScrollBarTop: 8px;
   --ScrollBarWidth: 40px;
   --ScrollBarLeft: 20px;
 }
-.Editor .EditorRow {
+.Editor[data-uid="42"] .EditorRow {
   height: var(--EditorRowHeight);
   line-height: var(--EditorRowHeight);
 }
-.Editor .ScrollBarThumbVertical {
+.Editor[data-uid="42"] .ScrollBarThumbVertical {
   height: var(--ScrollBarHeight);
   translate: 0px var(--ScrollBarTop);
 }
-.Editor .ScrollBarThumbHorizontal {
+.Editor[data-uid="42"] .ScrollBarThumbHorizontal {
   width: var(--ScrollBarWidth);
   translate: var(--ScrollBarLeft) 0px;
 }

--- a/packages/editor-worker/test/GetEditorVirtualDom.test.ts
+++ b/packages/editor-worker/test/GetEditorVirtualDom.test.ts
@@ -24,12 +24,14 @@ test('getEditorVirtualDom', () => {
     scrollBarHeight: 24,
     selectionInfos: [1, 2, 3, 4],
     textInfos: [['#', 'Token Comment']],
+    uid: 42,
   })
 
   expect(dom).toEqual([
     {
       childCount: 2,
       className: 'Viewlet Editor',
+      'data-uid': 42,
       onContextMenu: DomEventListenerFunctions.HandleContextMenu,
       role: 'code',
       type: VirtualDomElements.Div,
@@ -183,11 +185,13 @@ test('getEditorVirtualDom - line numbers disabled', () => {
     gutterInfos: [1],
     lineNumbers: false,
     textInfos: [],
+    uid: 42,
   })
 
   expect(dom[0]).toEqual({
     childCount: 1,
     className: 'Viewlet Editor',
+    'data-uid': 42,
     onContextMenu: DomEventListenerFunctions.HandleContextMenu,
     role: 'code',
     type: VirtualDomElements.Div,
@@ -200,12 +204,14 @@ test('getEditorVirtualDom - load error', () => {
     differences: [],
     loadError: 'Failed to read file',
     textInfos: [],
+    uid: 42,
   })
 
   expect(dom).toEqual([
     {
       childCount: 2,
       className: 'Viewlet TextEditorError',
+      'data-uid': 42,
       role: 'code',
       type: VirtualDomElements.Div,
     },

--- a/packages/editor-worker/test/RenderCss.test.ts
+++ b/packages/editor-worker/test/RenderCss.test.ts
@@ -19,22 +19,22 @@ test('renderCss', () => {
   expect(renderCss({} as any, newState as any)).toEqual([
     ViewletCommand.SetCss,
     1,
-    `.Editor {
+    `.Editor[data-uid="1"] {
   --EditorRowHeight: 20px;
   --ScrollBarHeight: 24px;
   --ScrollBarTop: 8px;
   --ScrollBarWidth: 40px;
   --ScrollBarLeft: 20px;
 }
-.Editor .EditorRow {
+.Editor[data-uid="1"] .EditorRow {
   height: var(--EditorRowHeight);
   line-height: var(--EditorRowHeight);
 }
-.Editor .ScrollBarThumbVertical {
+.Editor[data-uid="1"] .ScrollBarThumbVertical {
   height: var(--ScrollBarHeight);
   translate: 0px var(--ScrollBarTop);
 }
-.Editor .ScrollBarThumbHorizontal {
+.Editor[data-uid="1"] .ScrollBarThumbHorizontal {
   width: var(--ScrollBarWidth);
   translate: var(--ScrollBarLeft) 0px;
 }


### PR DESCRIPTION
Scope generated editor CSS to each editor instance so inactive editors cannot leak scrollbar dimensions into the active tab. Adds regression coverage for switching from a scrollable editor to a shorter file.