### PR TITLE
fix: preserve editor diagnostics

### DIFF
--- a/packages/editor-worker/src/parts/CreateEditor/CreateEditor.ts
+++ b/packages/editor-worker/src/parts/CreateEditor/CreateEditor.ts
@@ -174,15 +174,12 @@ export const createEditor = async ({
   // @ts-ignore
   await ExtensionHostWorker.invoke(ExtensionHostCommandType.TextDocumentSyncFull, uri, id, languageId, content)
 
-  // TODO await promise
-  if (diagnosticsEnabled) {
-    await UpdateDiagnostics.updateDiagnostics(newEditor4)
-  }
+  const editorWithDiagnostics = diagnosticsEnabled ? await UpdateDiagnostics.updateDiagnostics(newEditor4) : newEditor4
 
   const completionsOnTypeRaw = await Preferences.get('editor.completionsOnType')
   const completionsOnType = Boolean(completionsOnTypeRaw)
   EditorState.set(id, emptyEditor, {
-    ...newEditor4,
+    ...editorWithDiagnostics,
     completionsOnType,
   })
 }

--- a/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
@@ -123,15 +123,12 @@ export const loadContent = async (state: EditorState, savedState: unknown) => {
   // @ts-ignore
   await ExtensionHostWorker.invoke(ExtensionHostCommandType.TextDocumentSyncFull, uri, id, computedLanguageId, content)
 
-  // TODO await promise
-  if (diagnosticsEnabled) {
-    await UpdateDiagnostics.updateDiagnostics(newEditor4)
-  }
+  const editorWithDiagnostics = diagnosticsEnabled ? await UpdateDiagnostics.getEditorWithDiagnostics(newEditor4) : newEditor4
 
   const completionsOnTypeRaw = await Preferences.get('editor.completionsOnType')
   const completionsOnType = Boolean(completionsOnTypeRaw)
   const newEditor5: EditorState = {
-    ...newEditor4,
+    ...editorWithDiagnostics,
     completionsOnType,
     initial: false,
   }

--- a/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
+++ b/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
@@ -7,47 +7,63 @@ import * as GetVisibleDiagnostics from '../GetVisibleDiagnostics/GetVisibleDiagn
 import * as TextDocument from '../TextDocument/TextDocument.ts'
 import * as UpdateDiagnosticsWithLinks from './UpdateDiagnosticsWithLinks.ts'
 
-export const updateDiagnostics = async (newState: any): Promise<any> => {
+const getDiagnostics = async (editor: any): Promise<readonly any[]> => {
+  const content = TextDocument.getText(editor)
+  // @ts-ignore
+  await ExtensionHostWorker.invoke(ExtensionHostCommandType.TextDocumentSyncFull, editor.uri, editor.id, editor.languageId, content)
+  return ExtensionHostDiagnostic.executeDiagnosticProvider(editor)
+}
+
+const addDiagnostics = async (editor: any, diagnostics: readonly any[]): Promise<any> => {
+  const visualDecorations = await GetVisibleDiagnostics.getVisibleDiagnostics(editor, diagnostics)
+  const diagnosticDecorations = visualDecorations.flatMap((decoration: any) => [
+    decoration.offset,
+    decoration.length,
+    decoration.type,
+    decoration.modifiers || 0,
+  ])
+  const decorations = UpdateDiagnosticsWithLinks.mergeLinksWithDiagnosticDecorations(editor, diagnosticDecorations)
+  return {
+    ...editor,
+    decorations,
+    diagnostics,
+    visualDecorations,
+  }
+}
+
+const handleError = (error: unknown, editor: any): any => {
+  if (error instanceof Error && error.message.includes('No diagnostic provider found')) {
+    return editor
+  }
+  console.error(`Failed to update diagnostics: ${error}`)
+  return editor
+}
+
+export const getEditorWithDiagnostics = async (editor: any): Promise<any> => {
   try {
-    // TODO handle error
-    // TODO handle race condition
+    const diagnostics = await getDiagnostics(editor)
+    if (!EditorState.get(editor.id)) {
+      return editor
+    }
+    return addDiagnostics(editor, diagnostics)
+  } catch (error) {
+    return handleError(error, editor)
+  }
+}
 
-    // TODO sync textdocument incrementally
-    // TODO sync and ask for diagnostics at the same time?
-    // TODO throttle diagnostics
-    const content = TextDocument.getText(newState)
-
-    // TODO don't really need text document sync response
-    // could perhaps save a lot of messages by using send instead of invoke
-    // @ts-ignore
-    await ExtensionHostWorker.invoke(ExtensionHostCommandType.TextDocumentSyncFull, newState.uri, newState.id, newState.languageId, content)
-
-    const diagnostics = await ExtensionHostDiagnostic.executeDiagnosticProvider(newState)
-    const latest = EditorState.get(newState.id)
+export const updateDiagnostics = async (editor: any): Promise<any> => {
+  try {
+    const diagnostics = await getDiagnostics(editor)
+    const latest = EditorState.get(editor.id)
     if (!latest) {
-      return newState
+      return editor
     }
-    const visualDecorations = await GetVisibleDiagnostics.getVisibleDiagnostics(latest.newState, diagnostics)
-    // Get diagnostic decorations from visual decorations (if any)
-    const diagnosticDecorations = visualDecorations.flatMap((deco: any) => [deco.offset, deco.length, deco.type, deco.modifiers || 0])
-    // Merge link decorations with diagnostic decorations
-    const mergedDecorations = UpdateDiagnosticsWithLinks.mergeLinksWithDiagnosticDecorations(latest.newState, diagnosticDecorations)
-    const newEditor = {
-      ...latest.newState,
-      decorations: mergedDecorations, // Text-level decorations (flat array) for CSS classes
-      diagnostics,
-      visualDecorations, // Visual decorations (objects with x, y, width, height) for squiggly underlines
-    }
-    EditorState.set(newState.id, latest.oldState, newEditor)
+    const newEditor = await addDiagnostics(latest.newState, diagnostics)
+    EditorState.set(editor.id, latest.oldState, newEditor)
     // @ts-ignore
-    await RendererWorker.invoke('Editor.rerender', newState.id)
+    await RendererWorker.invoke('Editor.rerender', editor.id)
     return newEditor
   } catch (error) {
-    // @ts-ignore
-    if (error && error.message.includes('No diagnostic provider found')) {
-      return newState
-    }
-    console.error(`Failed to update diagnostics: ${error}`)
-    return newState
+    return handleError(error, editor)
   }
 }

--- a/packages/editor-worker/test/LoadContent.test.ts
+++ b/packages/editor-worker/test/LoadContent.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const getEditorPreferencesMock: any = jest.fn()
+const getEditorWithDiagnosticsMock: any = jest.fn()
 const getLanguagesMock: any = jest.fn()
+const getVisibleMock: any = jest.fn()
 const getTokenizerMock: any = jest.fn()
 const loadTokenizerMock: any = jest.fn()
 const measureCharacterWidthMock: any = jest.fn()
@@ -37,6 +39,10 @@ jest.unstable_mockModule('../src/parts/GetEditorPreferences/GetEditorPreferences
   getEditorPreferences: getEditorPreferencesMock,
 }))
 
+jest.unstable_mockModule('../src/parts/EditorText/EditorText.ts', () => ({
+  getVisible: getVisibleMock,
+}))
+
 jest.unstable_mockModule('../src/parts/GetLanguages/GetLanguages.ts', () => ({
   getLanguages: getLanguagesMock,
 }))
@@ -48,6 +54,10 @@ jest.unstable_mockModule('../src/parts/MeasureCharacterWidth/MeasureCharacterWid
 jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.ts', () => ({
   getTokenizer: getTokenizerMock,
   loadTokenizer: loadTokenizerMock,
+}))
+
+jest.unstable_mockModule('../src/parts/UpdateDiagnostics/UpdateDiagnostics.ts', () => ({
+  getEditorWithDiagnostics: getEditorWithDiagnosticsMock,
 }))
 
 const LoadContent = await import('../src/parts/LoadContent/LoadContent.ts')
@@ -95,7 +105,9 @@ const createState = () =>
 
 beforeEach(() => {
   getEditorPreferencesMock.mockReset()
+  getEditorWithDiagnosticsMock.mockReset()
   getLanguagesMock.mockReset()
+  getVisibleMock.mockReset()
   getTokenizerMock.mockReset()
   loadTokenizerMock.mockReset()
   measureCharacterWidthMock.mockReset()
@@ -117,7 +129,9 @@ beforeEach(() => {
     tabSize: 2,
   })
   getLanguagesMock.mockResolvedValue([{ extensions: ['.txt'], id: 'plaintext', tokenize: '' }])
+  getVisibleMock.mockResolvedValue({ differences: [], textInfos: [] })
   getTokenizerMock.mockReturnValue({})
+  getEditorWithDiagnosticsMock.mockImplementation(async (editor: any) => editor)
   measureCharacterWidthMock.mockResolvedValue(8)
 })
 
@@ -132,4 +146,34 @@ test('loadContent returns error state when reading file fails', async () => {
   expect(result.textInfos).toEqual([])
   expect(result.height).toBe(200)
   expect(readFileMock).toHaveBeenCalledWith('file:///test.txt')
+})
+
+test('loadContent preserves loaded text and diagnostics', async () => {
+  const diagnostics = [{ message: 'diagnostic' }]
+  getEditorPreferencesMock.mockResolvedValue({
+    completionTriggerCharacters: [],
+    diagnosticsEnabled: true,
+    fontFamily: 'monospace',
+    fontSize: 14,
+    fontWeight: 400,
+    isAutoClosingBracketsEnabled: false,
+    isAutoClosingQuotesEnabled: false,
+    isAutoClosingTagsEnabled: false,
+    isQuickSuggestionsEnabled: false,
+    letterSpacing: 0,
+    lineNumbers: true,
+    rowHeight: 20,
+    tabSize: 2,
+  })
+  readFileMock.mockResolvedValue('test')
+  getEditorWithDiagnosticsMock.mockImplementation(async (editor: any) => ({
+    ...editor,
+    diagnostics,
+  }))
+
+  const result = await LoadContent.loadContent(createState(), undefined)
+
+  expect(result.diagnostics).toBe(diagnostics)
+  expect(result.lines).toEqual(['test'])
+  expect(getEditorWithDiagnosticsMock).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
Preserve asynchronously loaded diagnostics when editor creation or content loading completes so diagnostic state and squiggles remain visible.