### PR TITLE
fix: restore syntax highlighting for duplicate languages

### DIFF
--- a/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
@@ -19,8 +19,8 @@ import * as UpdateDiagnostics from '../UpdateDiagnostics/UpdateDiagnostics.ts'
 
 const getTokenizePath = (languages: readonly any[], languageId: string): string => {
   for (const language of languages) {
-    if (language?.id === languageId) {
-      return language.tokenize || ''
+    if (language?.id === languageId && language.tokenize) {
+      return language.tokenize
     }
   }
   return ''

--- a/packages/editor-worker/test/LoadContent.test.ts
+++ b/packages/editor-worker/test/LoadContent.test.ts
@@ -177,3 +177,15 @@ test('loadContent preserves loaded text and diagnostics', async () => {
   expect(result.lines).toEqual(['test'])
   expect(getEditorWithDiagnosticsMock).toHaveBeenCalledTimes(1)
 })
+
+test('loadContent uses a tokenizer from a later contribution for the same language', async () => {
+  getLanguagesMock.mockResolvedValue([
+    { extensions: ['.txt'], id: 'plaintext' },
+    { id: 'plaintext', tokenize: '/test/tokenizePlainText.js' },
+  ])
+  readFileMock.mockResolvedValue('test')
+
+  await LoadContent.loadContent(createState(), undefined)
+
+  expect(loadTokenizerMock).toHaveBeenCalledWith('plaintext', '/test/tokenizePlainText.js')
+})


### PR DESCRIPTION
Fixes tokenizer selection when a language-features extension contributes the same language id before its language-basics tokenizer. TypeScript files now retain syntax highlighting in extension fixtures.