### PR TITLE
fix: use selection offset for brace completion

### DIFF
--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandBraceCompletion.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandBraceCompletion.ts
@@ -24,8 +24,7 @@ const getMatchingClosingBrace = (brace) => {
 
 export const braceCompletion = async (editor: any, text: string) => {
   try {
-    // @ts-ignore
-    const offset = TextDocument.offsetAt(editor, editor.cursor)
+    const offset = getCursorOffset(editor)
     // @ts-ignore
     const result = await RendererWorker.invoke('ExtensionHostBraceCompletion.executeBraceCompletionProvider', editor, offset, text)
     if (result) {
@@ -43,4 +42,8 @@ export const braceCompletion = async (editor: any, text: string) => {
     // @ts-ignore
     return EditorShowMessage.showErrorMessage(editor, position, getErrorMessage(error))
   }
+}
+
+export const getCursorOffset = (editor: any): number => {
+  return TextDocument.offsetAt(editor, editor.selections[0], editor.selections[1])
 }

--- a/packages/editor-worker/test/EditorCommandBraceCompletion.test.ts
+++ b/packages/editor-worker/test/EditorCommandBraceCompletion.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@jest/globals'
+import * as EditorCommandBraceCompletion from '../src/parts/EditorCommand/EditorCommandBraceCompletion.ts'
+
+test('getCursorOffset returns the offset at the editor cursor', () => {
+  const editor = {
+    lines: ['ab', 'cd'],
+    selections: new Uint32Array([1, 1, 1, 1]),
+  }
+
+  expect(EditorCommandBraceCompletion.getCursorOffset(editor)).toBe(4)
+})


### PR DESCRIPTION
## Summary
- compute brace-completion offsets from the canonical editor selection buffer
- add regression coverage for multi-line cursor offsets

## Validation
- npm run lint
- npm run type-check
- npm test
- npm run build
- combined TypeScript completion E2E coverage