### PR TITLE
fix: dispose editor widgets

### DIFF
--- a/packages/build/src/config.ts
+++ b/packages/build/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 830_000
+export const threshold = 840_000
 
 export const workerPath = join(root, '.tmp/dist/dist/editorWorkerMain.js')
 

--- a/packages/editor-worker/src/parts/Api/Api.ts
+++ b/packages/editor-worker/src/parts/Api/Api.ts
@@ -1,9 +1,11 @@
 interface EventMap {
+  'ColorPicker.dispose': (uid: number) => Promise<void>
   'ColorPicker.handleSliderPointerDown': (state: any, x: number, y: number) => Promise<any>
   'ColorPicker.handleSliderPointerMove': (state: any, x: number, y: number) => Promise<any>
   'ColorPicker.loadContent': (state: any) => Promise<any>
   'ColorPicker.render': (oldState: any, newState: any) => Promise<any>
   'Editor.create': (options: any) => Promise<void>
+  'Editor.dispose': (editorUid: number) => Promise<readonly any[]>
   'Editor.getQuickPickMenuEntries': () => Promise<readonly any[]>
   'Editor.offsetAt': (textDocument: any, positionRowIndex: number, positionColumnIndex: number) => Promise<any>
   'Editor.render': (editorUid: number) => Promise<any>

--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -5,6 +5,7 @@ import * as ColorPicker from '../ColorPicker/ColorPicker.ts'
 import { createEditor2 } from '../CreateEditor2/CreateEditor2.ts'
 import * as CreateEditor from '../CreateEditor/CreateEditor.ts'
 import { diff2 } from '../Diff2/Diff2.ts'
+import * as DisposeEditor from '../DisposeEditor/DisposeEditor.ts'
 import * as AddCursorAbove from '../EditorCommand/EditorCommandAddCursorAbove.ts'
 import * as AddCursorBelow from '../EditorCommand/EditorCommandAddCursorBelow.ts'
 import * as EditorCommandApplyDocumentEdits from '../EditorCommand/EditorCommandApplyDocumentEdits.ts'
@@ -225,6 +226,7 @@ export const commandMap = {
   'Editor.deleteWordPartRight': wrapCommand(DeleteWordPartRight.deleteWordPartRight),
   'Editor.deleteWordRight': wrapCommand(DeleteWordRight.deleteWordRight),
   'Editor.diff2': diff2,
+  'Editor.dispose': DisposeEditor.disposeEditor,
   'Editor.executeWidgetCommand': wrapCommand(ExecuteWidgetCommand.executeWidgetCommand),
   'Editor.findAllReferences': wrapCommand(FindAllReferences.findAllReferences),
   'Editor.format': wrapCommand(EditorFormat.format),

--- a/packages/editor-worker/src/parts/DisposeEditor/DisposeEditor.ts
+++ b/packages/editor-worker/src/parts/DisposeEditor/DisposeEditor.ts
@@ -1,0 +1,22 @@
+import { WidgetId } from '@lvce-editor/constants'
+import * as ColorPickerWorker from '../ColorPickerWorker/ColorPickerWorker.ts'
+import * as EditorStates from '../EditorStates/EditorStates.ts'
+import * as RenderWidgets from '../RenderWidgets/RenderWidgets.ts'
+
+export const disposeEditor = async (editorUid: number): Promise<readonly any[]> => {
+  const editor = EditorStates.get(editorUid)?.newState
+  if (!editor) {
+    return []
+  }
+  for (const widget of editor.widgets) {
+    if (widget.id === WidgetId.ColorPicker) {
+      await ColorPickerWorker.invoke('ColorPicker.dispose', widget.newState.uid)
+    }
+  }
+  const commands = RenderWidgets.renderWidgets(editor, {
+    ...editor,
+    widgets: [],
+  })
+  EditorStates.dispose(editorUid)
+  return commands
+}

--- a/packages/editor-worker/src/parts/EditorStates/EditorStates.ts
+++ b/packages/editor-worker/src/parts/EditorStates/EditorStates.ts
@@ -3,7 +3,7 @@ import type { EditorState } from '../State/State.ts'
 
 const editorStates = ViewletRegistry.create<EditorState>()
 
-export const { diff, getCommandIds, registerCommands, wrapCommand, wrapGetter } = editorStates
+export const { diff, dispose, getCommandIds, registerCommands, wrapCommand, wrapGetter } = editorStates
 
 export const get = (id: number): ViewletRegistry.StateTuple<EditorState> => {
   return editorStates.get(id)

--- a/packages/editor-worker/src/parts/RemoveWidget/RemoveWidget.ts
+++ b/packages/editor-worker/src/parts/RemoveWidget/RemoveWidget.ts
@@ -2,5 +2,5 @@ import type { Widget } from '../Widget/Widget.ts'
 
 export const removeWidget = <T>(widget: Widget<T>): readonly any[] => {
   // @ts-ignore
-  return [['Viewlet.send', widget.newState.uid, 'dispose']]
+  return [['Viewlet.dispose', widget.newState.uid]]
 }

--- a/packages/editor-worker/test/DisposeEditor.test.ts
+++ b/packages/editor-worker/test/DisposeEditor.test.ts
@@ -1,0 +1,36 @@
+import { expect, jest, test } from '@jest/globals'
+import { WidgetId } from '@lvce-editor/constants'
+
+jest.unstable_mockModule('../src/parts/ColorPickerWorker/ColorPickerWorker.ts', () => ({
+  invoke: jest.fn(),
+}))
+
+const ColorPickerWorker = await import('../src/parts/ColorPickerWorker/ColorPickerWorker.ts')
+const DisposeEditor = await import('../src/parts/DisposeEditor/DisposeEditor.ts')
+const EditorStates = await import('../src/parts/EditorStates/EditorStates.ts')
+const RegisterWidgets = await import('../src/parts/RegisterWidgets/RegisterWidgets.ts')
+
+RegisterWidgets.registerWidgets()
+
+test('disposes editor widgets and state', async () => {
+  const editorUid = 900_001
+  const editor = {
+    uid: editorUid,
+    widgets: [
+      {
+        id: WidgetId.ColorPicker,
+        newState: { uid: 900_002 },
+        oldState: { uid: 900_002 },
+      },
+    ],
+  }
+  EditorStates.set(editorUid, editor as any, editor as any)
+
+  await expect(DisposeEditor.disposeEditor(editorUid)).resolves.toEqual([['Viewlet.dispose', 900_002]])
+  expect(ColorPickerWorker.invoke).toHaveBeenCalledWith('ColorPicker.dispose', 900_002)
+  expect(EditorStates.get(editorUid)).toBeUndefined()
+})
+
+test('does nothing when editor is already disposed', async () => {
+  await expect(DisposeEditor.disposeEditor(900_003)).resolves.toEqual([])
+})

--- a/packages/editor-worker/test/RemoveWidget.test.ts
+++ b/packages/editor-worker/test/RemoveWidget.test.ts
@@ -16,5 +16,5 @@ test('remove widget', () => {
       uid: 123,
     },
   }
-  expect(RemoveWidget.removeWidget(widget)).toEqual([['Viewlet.send', 123, 'dispose']])
+  expect(RemoveWidget.removeWidget(widget)).toEqual([['Viewlet.dispose', 123]])
 })


### PR DESCRIPTION
Dispose an editor’s widget roots and backing color-picker state when the editor closes, then remove the editor state from the worker registry.