### PR TITLE
fix: improve diagnostics error reporting

### DIFF
--- a/packages/editor-worker/src/parts/ErrorHandling/ErrorHandling.ts
+++ b/packages/editor-worker/src/parts/ErrorHandling/ErrorHandling.ts
@@ -1,59 +1,23 @@
-// @ts-nocheck
-import * as PrettyError from '../PrettyError/PrettyError.ts'
+import { ErrorWorker } from '@lvce-editor/rpc-registry'
 
-const state = {
-  /**
-   * @type {string[]}
-   */
-  seenWarnings: [],
+const logError = async (error: unknown, prefix: string): Promise<void> => {
+  const prettyError = await ErrorWorker.invoke('Errors.prepare', error)
+  await ErrorWorker.invoke('Errors.print', prettyError, prefix)
 }
 
-const logError = async (error) => {
-  const prettyError = await PrettyError.prepare(error)
-  const prettyErrorString = PrettyError.print(prettyError)
-  console.error(prettyErrorString)
-  return prettyError
-}
-
-export const handleError = async (error) => {
-  try {
-    await logError(error)
-  } catch (otherError) {
-    console.warn('ErrorHandling error')
-    console.warn(otherError)
-    console.error(error)
-  }
-}
-
-const warn = (...args) => {
-  const stringified = JSON.stringify(args)
-  if (state.seenWarnings.includes(stringified)) {
+const logFallback = (error: unknown, prefix: string): void => {
+  if (prefix) {
+    console.error(prefix, error)
     return
   }
-  state.seenWarnings.push(stringified)
-  console.warn(...args)
+  console.error(error)
 }
 
-/**
- * @param {PromiseRejectionEvent} event
- */
-const handleUnhandledRejection = async (event) => {
+export const handleError = async (error: unknown, prefix = ''): Promise<void> => {
   try {
-    event.preventDefault()
-    await handleError(event.reason)
-  } catch {
-    console.error(event.reason)
-  }
-}
-
-/**
- * @param {ErrorEvent} event
- */
-const handleUnhandledError = async (event) => {
-  try {
-    event.preventDefault()
-    await handleError(event.error)
-  } catch {
-    console.error(event.error)
+    await logError(error, prefix)
+  } catch (otherError) {
+    console.warn('ErrorHandling error', otherError)
+    logFallback(error, prefix)
   }
 }

--- a/packages/editor-worker/src/parts/InitializeErrorWorker/InitializeErrorWorker.ts
+++ b/packages/editor-worker/src/parts/InitializeErrorWorker/InitializeErrorWorker.ts
@@ -1,0 +1,12 @@
+import { LazyTransferMessagePortRpcParent } from '@lvce-editor/rpc'
+import { ErrorWorker, RendererWorker, RpcId } from '@lvce-editor/rpc-registry'
+
+export const initializeErrorWorker = async (): Promise<void> => {
+  const rpc = await LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send(port) {
+      return RendererWorker.sendMessagePortToErrorWorker(port, RpcId.EditorWorker)
+    },
+  })
+  ErrorWorker.set(rpc)
+}

--- a/packages/editor-worker/src/parts/Listen/Listen.ts
+++ b/packages/editor-worker/src/parts/Listen/Listen.ts
@@ -1,5 +1,6 @@
 import * as CommandMap from '../CommandMap/CommandMap.ts'
 import { registerCommands } from '../EditorStates/EditorStates.ts'
+import { initializeErrorWorker } from '../InitializeErrorWorker/InitializeErrorWorker.ts'
 import { initializeExtensionHost } from '../InitializeExtensionHost/InitializeExtensionHost.ts'
 import { initializeExtensionManagementWorker } from '../InitializeExtensionManagementWorker/InitializeExtensionManagementWorker.ts'
 import { initializeOpenerWorker } from '../InitializeOpenerWorker/InitializeOpenerWorker.ts'
@@ -10,6 +11,7 @@ export const listen = async () => {
   registerCommands(CommandMap.commandMap)
   await Promise.all([
     initializeRendererWorker(),
+    initializeErrorWorker(),
     initializeExtensionHost(),
     initializeExtensionManagementWorker(),
     initializeTextMeasurementWorker(),

--- a/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
+++ b/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
@@ -1,5 +1,6 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as EditorState from '../EditorStates/EditorStates.ts'
+import * as ErrorHandling from '../ErrorHandling/ErrorHandling.ts'
 import * as ExtensionHostCommandType from '../ExtensionHostCommandType/ExtensionHostCommandType.ts'
 import * as ExtensionHostDiagnostic from '../ExtensionHostDiagnostic/ExtensionHostDiagnostic.ts'
 import * as ExtensionHostWorker from '../ExtensionHostWorker/ExtensionHostWorker.ts'
@@ -31,11 +32,11 @@ const addDiagnostics = async (editor: any, diagnostics: readonly any[]): Promise
   }
 }
 
-const handleError = (error: unknown, editor: any): any => {
+const handleError = async (error: unknown, editor: any): Promise<any> => {
   if (error instanceof Error && error.message.includes('No diagnostic provider found')) {
     return editor
   }
-  console.error(`Failed to update diagnostics: ${error}`)
+  await ErrorHandling.handleError(error, 'Failed to update diagnostics: ')
   return editor
 }
 

--- a/packages/editor-worker/test/ErrorHandling.test.ts
+++ b/packages/editor-worker/test/ErrorHandling.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { registerMockRpc, remove, RpcId } from '@lvce-editor/rpc-registry'
+import * as ErrorHandling from '../src/parts/ErrorHandling/ErrorHandling.ts'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  remove(RpcId.ErrorWorker)
+})
+
+test('handleError prepares and prints the full error using the error worker', async () => {
+  const error = new Error('diagnostics failed')
+  const prettyError = {
+    codeFrame: '> 1 | const value: string = 1',
+    message: "Type 'number' is not assignable to type 'string'.",
+    stack: 'Error: diagnostics failed\n    at test.ts:1:23',
+  }
+  const mockRpc = registerMockRpc(RpcId.ErrorWorker, {
+    'Errors.prepare': async () => prettyError,
+    'Errors.print': async () => undefined,
+  })
+
+  await ErrorHandling.handleError(error, 'Failed to update diagnostics: ')
+
+  expect(mockRpc.invocations).toEqual([
+    ['Errors.prepare', error],
+    ['Errors.print', prettyError, 'Failed to update diagnostics: '],
+  ])
+})
+
+test('handleError logs the original error when the error worker fails', async () => {
+  const error = new Error('diagnostics failed')
+  const workerError = new Error('error worker failed')
+  const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+  const mockRpc = registerMockRpc(RpcId.ErrorWorker, {
+    'Errors.prepare': async () => {
+      throw workerError
+    },
+  })
+
+  await ErrorHandling.handleError(error, 'Failed to update diagnostics: ')
+
+  expect(consoleWarn).toHaveBeenCalledWith('ErrorHandling error', workerError)
+  expect(consoleError).toHaveBeenCalledWith('Failed to update diagnostics: ', error)
+  expect(mockRpc.invocations).toEqual([['Errors.prepare', error]])
+})

--- a/packages/editor-worker/test/UpdateDiagnostics.test.ts
+++ b/packages/editor-worker/test/UpdateDiagnostics.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, expect, test } from '@jest/globals'
+import { ExtensionHost, registerMockRpc, remove, RpcId } from '@lvce-editor/rpc-registry'
+import { getEditorWithDiagnostics } from '../src/parts/UpdateDiagnostics/UpdateDiagnostics.ts'
+
+afterEach(() => {
+  remove(RpcId.ErrorWorker)
+})
+
+test('getEditorWithDiagnostics reports failures through the error worker', async () => {
+  const error = new Error('diagnostics failed')
+  const prettyError = {
+    codeFrame: 'code frame',
+    message: 'diagnostics failed',
+    stack: error.stack,
+  }
+  using extensionHostRpc = ExtensionHost.registerMockRpc({
+    'ExtensionHostTextDocument.syncFull': async () => {
+      throw error
+    },
+  })
+  const errorWorkerRpc = registerMockRpc(RpcId.ErrorWorker, {
+    'Errors.prepare': async () => prettyError,
+    'Errors.print': async () => undefined,
+  })
+  const editor = {
+    id: 1,
+    languageId: 'typescript',
+    lines: ['const value: string = 1'],
+    uri: '/test.ts',
+  }
+
+  await expect(getEditorWithDiagnostics(editor)).resolves.toBe(editor)
+  expect(extensionHostRpc.invocations).toEqual([['ExtensionHostTextDocument.syncFull', '/test.ts', 1, 'typescript', 'const value: string = 1']])
+  expect(errorWorkerRpc.invocations).toEqual([
+    ['Errors.prepare', error],
+    ['Errors.print', prettyError, 'Failed to update diagnostics: '],
+  ])
+})


### PR DESCRIPTION
Routes diagnostics failures through the error worker so console output includes the prepared stack and codeframe, while preserving the original Error as a fallback.