### PR TITLE
feature: reuse page for e2e tests

### DIFF
--- a/packages/e2e/package-lock.json
+++ b/packages/e2e/package-lock.json
@@ -9,18 +9,46 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/test-with-playwright": "^22.1.0"
+        "@lvce-editor/test-with-playwright": "^22.8.0"
       }
     },
-    "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.1.0.tgz",
-      "integrity": "sha512-YpA12zCSdoLXIWOFpbtCgLruW9n3L7GZ/LMeyJh+16ICYmkVGQXE/i/tu/4qBzP6TWRgE/UBiCOGczSeYzR/IA==",
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/test-with-playwright-worker": "22.1.0",
-        "@lvce-editor/test-worker": "^16.5.0"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lvce-editor/test-with-playwright": {
+      "version": "22.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.8.0.tgz",
+      "integrity": "sha512-55+UhkfjAtnliaiKy+3e7xOX2xkM74m597r30vIL+TvWfx8A6Juq35c7DOW74vX7H2XPhS5jpOXDgjN/isrTdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/test-with-playwright-worker": "22.8.0",
+        "@lvce-editor/test-worker": "^17.2.0"
       },
       "bin": {
         "test-with-playwright": "bin/test-with-playwright.js"
@@ -30,34 +58,38 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.1.0.tgz",
-      "integrity": "sha512-LHNtZEx/5zI5k4ZFv/+0+GUsmzpurnRP+epwcLwQBtB+O4HM6+AqSAMwF/xfkhev6WxFK3D+kA0Fg2JibIqhYA==",
+      "version": "22.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.8.0.tgz",
+      "integrity": "sha512-8Spk+3ssZ1JX4ZxGvOB560uO4rP/gwENq9glicSZmxwJCDgk8Y64vZKPQrFO0/9savKDhqkcTTPVwybXB/hfyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@playwright/test": "1.61.0",
-        "get-port": "^7.2.0"
+        "@playwright/test": "1.61.1",
+        "get-port": "^7.2.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "v8-to-istanbul": "^9.3.0"
       },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/test-worker": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-16.7.0.tgz",
-      "integrity": "sha512-dlVVxhFpc57FygtF2e6+DuDI9GF03IDQwTqyzkaYogEksMza8Au/Mvf0r07CNPtQ3m3El0j/npbIkMF25r9NAg==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.2.0.tgz",
+      "integrity": "sha512-H5+w/8+hSjE/BivDtlvOxWkmZNEUgxSDNiAeY58A8lHiAByNVvivjlvTo8c2Y3wLiyx8PeSXxNQaukWLdXueHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -65,6 +97,20 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -94,14 +140,86 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -114,9 +232,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -124,6 +242,47 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     }
   }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "e2e": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --server-path=../server/src/server.js",
-    "e2e:headless": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --server-path=../server/src/server.js --headless",
+    "e2e": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --server-path=../server/src/server.js --reuse-page",
+    "e2e:headless": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --server-path=../server/src/server.js --headless --reuse-page",
     "type-check": "tsc"
   },
   "devDependencies": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -10,6 +10,6 @@
     "type-check": "tsc"
   },
   "devDependencies": {
-    "@lvce-editor/test-with-playwright": "^22.1.0"
+    "@lvce-editor/test-with-playwright": "^22.8.0"
   }
 }

--- a/packages/e2e/src/find-widget-binary-content.ts
+++ b/packages/e2e/src/find-widget-binary-content.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-binary-content'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange - create a file with binary-like content (null bytes, special chars)
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-case-insensitive-default.ts
+++ b/packages/e2e/src/find-widget-case-insensitive-default.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-case-insensitive-default'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-close-replace.ts
+++ b/packages/e2e/src/find-widget-close-replace.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.editor-close-replace'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-collapse-replace.ts
+++ b/packages/e2e/src/find-widget-collapse-replace.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-collapse-replace'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-empty-file.ts
+++ b/packages/e2e/src/find-widget-empty-file.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-empty-file'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-empty-search.ts
+++ b/packages/e2e/src/find-widget-empty-search.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-empty-search'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-focus-navigation-collapsed-no-results-backward.ts
+++ b/packages/e2e/src/find-widget-focus-navigation-collapsed-no-results-backward.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-focus-navigation-collapsed-no-results-backward'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-focus-navigation-collapsed-no-results-forward.ts
+++ b/packages/e2e/src/find-widget-focus-navigation-collapsed-no-results-forward.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-focus-navigation-collapsed-no-results-forward'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-focus-navigation-collapsed.ts
+++ b/packages/e2e/src/find-widget-focus-navigation-collapsed.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-focus-navigation-collapsed'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-focus-navigation-expanded.ts
+++ b/packages/e2e/src/find-widget-focus-navigation-expanded.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-focus-navigation-expanded'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-focus-next-wrap-around.ts
+++ b/packages/e2e/src/find-widget-focus-next-wrap-around.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-focus-next-wrap-around'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-focus-next.ts
+++ b/packages/e2e/src/find-widget-focus-next.ts
@@ -4,6 +4,8 @@ export const name = 'find-widget-focus-next'
 
 // TODO should only test one thing: focusing next match
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-focus-previous-wrap-around.ts
+++ b/packages/e2e/src/find-widget-focus-previous-wrap-around.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-focus-previous-wrap-around'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-handle-input.ts
+++ b/packages/e2e/src/find-widget-handle-input.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-handle-input'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-handle-replace-input.ts
+++ b/packages/e2e/src/find-widget-handle-replace-input.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-handle-replace-input'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-large-file.ts
+++ b/packages/e2e/src/find-widget-large-file.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-large-file'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange - create a large file with many lines
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-match-case.ts
+++ b/packages/e2e/src/find-widget-match-case.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-match-case'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-match-whole-word.ts
+++ b/packages/e2e/src/find-widget-match-whole-word.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-match-whole-word'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-multi-line-input.ts
+++ b/packages/e2e/src/find-widget-multi-line-input.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-multi-line-input'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-multiple-consecutive-replaces.ts
+++ b/packages/e2e/src/find-widget-multiple-consecutive-replaces.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-multiple-consecutive-replaces'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-narrow-width.ts
+++ b/packages/e2e/src/find-widget-narrow-width.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-narrow-width'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-no-results.ts
+++ b/packages/e2e/src/find-widget-no-results.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget.no-results'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-open-no-selection.ts
+++ b/packages/e2e/src/find-widget-open-no-selection.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-open-no-selection'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-open-replace.ts
+++ b/packages/e2e/src/find-widget-open-replace.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.editor-open-replace'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-open.ts
+++ b/packages/e2e/src/find-widget-open.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-open'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-regex-anchors.ts
+++ b/packages/e2e/src/find-widget-regex-anchors.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-regex-anchors'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-regex-lookahead.ts
+++ b/packages/e2e/src/find-widget-regex-lookahead.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-regex-lookahead'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-regular-expression-invalid.ts
+++ b/packages/e2e/src/find-widget-regular-expression-invalid.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-regular-expression-invalid'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-replace-creates-matches.ts
+++ b/packages/e2e/src/find-widget-replace-creates-matches.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-replace-creates-matches'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-replace-input-focus.ts
+++ b/packages/e2e/src/find-widget-replace-input-focus.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-replace-input-focus'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-replace-keeps-widget-visible.ts
+++ b/packages/e2e/src/find-widget-replace-keeps-widget-visible.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-replace-keeps-widget-visible'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-replace-sequential.ts
+++ b/packages/e2e/src/find-widget-replace-sequential.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-replace-sequential'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-replace-updates-match-count.ts
+++ b/packages/e2e/src/find-widget-replace-updates-match-count.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.find-replace-updates-match-count'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-replace-with-regex-invalid.ts
+++ b/packages/e2e/src/find-widget-replace-with-regex-invalid.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-replace-with-regex-invalid'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-single-character-search.ts
+++ b/packages/e2e/src/find-widget-single-character-search.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-single-character-search'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-special-characters.ts
+++ b/packages/e2e/src/find-widget-special-characters.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-special-characters'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-tab-character-search.ts
+++ b/packages/e2e/src/find-widget-tab-character-search.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-tab-character-search'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-toggle-match-case-off.ts
+++ b/packages/e2e/src/find-widget-toggle-match-case-off.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-toggle-match-case-off'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-unicode-search.ts
+++ b/packages/e2e/src/find-widget-unicode-search.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-unicode-search'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-use-regular-expression.ts
+++ b/packages/e2e/src/find-widget-use-regular-expression.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-use-regular-expression'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-very-long-line.ts
+++ b/packages/e2e/src/find-widget-very-long-line.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-very-long-line'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange - create a file with a very long line
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/find-widget-whitespace-search.ts
+++ b/packages/e2e/src/find-widget-whitespace-search.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-whitespace-search'
 
+export const skip = 1
+
 export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()


### PR DESCRIPTION
Enable the Playwright reuse-page mode for both interactive and headless editor-worker e2e test runs.