### PR TITLE
fix: stabilize find widget keyboard test

### DIFF
--- a/packages/e2e/src/find-widget-keyboard-navigation.ts
+++ b/packages/e2e/src/find-widget-keyboard-navigation.ts
@@ -17,11 +17,12 @@ content 3`,
   await Editor.openFind()
 
   // assert - find input should be focused initially
-  const findWidgetInput = Locator('.FindWidget .MultilineInputBox')
+  const findWidget = Locator('.FindWidget:has(.MultilineInputBox:focus)')
+  const findWidgetInput = findWidget.locator('.MultilineInputBox')
   await expect(findWidgetInput).toBeVisible()
   await expect(findWidgetInput).toBeFocused()
 
-  const findWidgetMatchCount = Locator(`.FindWidgetMatchCount`)
+  const findWidgetMatchCount = findWidget.locator(`.FindWidgetMatchCount`)
   await expect(findWidgetMatchCount).toHaveText('1 of 3')
 
   // act - go to next match using the real keyboard path


### PR DESCRIPTION
Scopes the keyboard-navigation assertions to the focused find widget so reused-page e2e runs ignore stale widget roots from earlier tests.