### PR TITLE
fix: remove source actions when editor closes

### DIFF
--- a/packages/e2e/src/editor.source-actions-close-on-editor-close.ts
+++ b/packages/e2e/src/editor.source-actions-close-on-editor-close.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.source-actions-close-on-editor-close'
+
+export const test: Test = async ({ Editor, expect, Extension, FileSystem, Locator, Main }) => {
+  // arrange
+  const url = import.meta.resolve('../fixtures/editor.source-actions-execute')
+  await Extension.addWebExtension(url)
+  const tmpDir = await FileSystem.getTmpDir()
+  const file = `${tmpDir}/src/source-actions-close.xyz`
+  await FileSystem.writeFile(file, 'globalThis.AbortSignal.abort()')
+  await Main.openUri(file)
+  await Editor.setCursor(0, 11)
+  await Editor.openSourceActions()
+  const sourceActions = Locator('.EditorSourceActions')
+  await expect(sourceActions).toBeVisible()
+
+  // act
+  await Main.closeAllEditors()
+
+  // assert
+  await expect(sourceActions).toBeHidden()
+}

--- a/packages/editor-worker/test/DisposeEditor.test.ts
+++ b/packages/editor-worker/test/DisposeEditor.test.ts
@@ -22,11 +22,19 @@ test('disposes editor widgets and state', async () => {
         newState: { uid: 900_002 },
         oldState: { uid: 900_002 },
       },
+      {
+        id: WidgetId.SourceAction,
+        newState: { uid: 900_004 },
+        oldState: { uid: 900_004 },
+      },
     ],
   }
   EditorStates.set(editorUid, editor as any, editor as any)
 
-  await expect(DisposeEditor.disposeEditor(editorUid)).resolves.toEqual([['Viewlet.dispose', 900_002]])
+  await expect(DisposeEditor.disposeEditor(editorUid)).resolves.toEqual([
+    ['Viewlet.dispose', 900_002],
+    ['Viewlet.dispose', 900_004],
+  ])
   expect(ColorPickerWorker.invoke).toHaveBeenCalledWith('ColorPicker.dispose', 900_002)
   expect(EditorStates.get(editorUid)).toBeUndefined()
 })

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "^0.91.7"
+        "@lvce-editor/server": "^0.91.8"
       },
       "devDependencies": {
         "@types/node": "^25.9.3"
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.91.7",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.91.7.tgz",
-      "integrity": "sha512-Dj0JwH//WlnxOVOO4CFgkwooElPCsU5zvbHY4NbU9ILvRPJ0Buu0rTUnJ79xZfO73D/NoTlmJOeN40QF8iTIVQ==",
+      "version": "0.91.8",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.91.8.tgz",
+      "integrity": "sha512-pmonHf2dKohXuenu2GbdLyIbQUeEQEtmXNe21xKgTSoxGxOwDws9ERytwP1gj1kgVQFFYdGhmvilxEqPQCaZKg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
@@ -497,13 +497,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.91.7",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.91.7.tgz",
-      "integrity": "sha512-LNO0KhXx9/ns8pX1hviFUyBh43Gjncg8vBnT5Wu2NDvMBvCMM2BNwU2YyBvadViF8j76Uh5ujry7dEBESMHC/g==",
+      "version": "0.91.8",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.91.8.tgz",
+      "integrity": "sha512-138Heox0Wh6PGBYXFn0dkvswrtOBA5LBzXrYQEf6ZhvJJGGbUa8Z/JAc8eR7O+qNBcYlUTsfTzse1M8+e4u9PQ==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.91.7",
-        "@lvce-editor/static-server": "0.91.7"
+        "@lvce-editor/shared-process": "0.91.8",
+        "@lvce-editor/static-server": "0.91.8"
       },
       "bin": {
         "server": "bin/server.js"
@@ -513,14 +513,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.91.7",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.91.7.tgz",
-      "integrity": "sha512-K/w0GhIh0M08OGdwkjFSFGglekKhXGKLiUF5LaS0L9Y4WN520Jrct6ujvgFMCDJPGTptgimuWbw8zUsJLsUEKA==",
+      "version": "0.91.8",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.91.8.tgz",
+      "integrity": "sha512-3L5SCUJgbcnecoABkkcaQx0Qc2irmxZwyqjUQBgqZrsXpxm+8k2T+u2PCtuNYKcEstxuUp2lb6hhw66XlJRkBw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
         "@lvce-editor/auth-process": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.91.7",
+        "@lvce-editor/extension-host-helper-process": "0.91.8",
         "@lvce-editor/ipc": "16.3.0",
         "@lvce-editor/json-rpc": "8.2.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -552,9 +552,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.91.7",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.91.7.tgz",
-      "integrity": "sha512-/wAWysCCDVcjy0a14kDo4DA4QT7RIGNb4JOTHRHWHz/2yuyfZuFMQto5ubGVw4qsyLH3tBdL+luC/wxq1Lx1uw==",
+      "version": "0.91.8",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.91.8.tgz",
+      "integrity": "sha512-MgxFQcPb2WBjRw/iVxmSk4F7ymgiWB6Av4sXOsFiOB/pgeE9fx7WKAxotiYimYptLx+HqDySYkRPNl0sHWKPxA==",
       "license": "MIT",
       "engines": {
         "node": ">=24"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "^0.91.7"
+    "@lvce-editor/server": "^0.91.8"
   },
   "devDependencies": {
     "@types/node": "^25.9.3"


### PR DESCRIPTION
## Summary

- add an e2e regression for closing an editor while source actions are open
- cover source action widget disposal in the editor-worker unit test
- update the test server to the release that awaits editor disposal