### PR TITLE
fix: save editor on blur when auto save is enabled

### DIFF
--- a/packages/editor-worker/src/parts/Editor/Editor.ts
+++ b/packages/editor-worker/src/parts/Editor/Editor.ts
@@ -115,7 +115,7 @@ export const scheduleDocumentAndCursorsSelections = async (editor: any, changes:
 
   // Notify main-area-worker about modified status change
   if (!editor.modified) {
-    await TabModifiedStatusChange.notifyTabModifiedStatusChange(editor.uri)
+    await TabModifiedStatusChange.notifyTabModifiedStatusChange(editor.uri, true)
   }
 
   // Notify registered listeners about editor changes

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandBlur.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandBlur.ts
@@ -1,6 +1,8 @@
 import type { EditorState } from '../State/State.ts'
+import * as Preferences from '../Preferences/Preferences.ts'
+import * as EditorCommandSave from './EditorCommandSave.ts'
 
-export const handleBlur = (editor: EditorState): EditorState => {
+export const handleBlur = async (editor: EditorState): Promise<EditorState> => {
   if (!editor.focused) {
     return editor
   }
@@ -8,5 +10,12 @@ export const handleBlur = (editor: EditorState): EditorState => {
     ...editor,
     focused: false,
   }
-  return newEditor
+  if (!editor.modified) {
+    return newEditor
+  }
+  const autoSave = await Preferences.get('files.autoSave')
+  if (autoSave === 'off') {
+    return newEditor
+  }
+  return EditorCommandSave.save(newEditor)
 }

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandSave.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandSave.ts
@@ -1,5 +1,6 @@
 import { PlatformType } from '@lvce-editor/constants'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.ts'
+import * as TabModifiedStatusChange from '../TabModifiedStatusChange/TabModifiedStatusChange.ts'
 import * as TextDocument from '../TextDocument/TextDocument.ts'
 import { VError } from '../VError/VError.ts'
 import { getNewEditor } from './EditorCommandSave/getNewEditor.ts'
@@ -16,11 +17,17 @@ export const save = async (editor: any): Promise<any> => {
     if (isUntitledFile(uri)) {
       const pickedFilePath = await saveUntitledFile(uri, content, platform)
       if (pickedFilePath) {
+        if (editor.modified) {
+          await TabModifiedStatusChange.notifyTabModifiedStatusChange(uri, false)
+        }
         return { ...newEditor, modified: false, uri: pickedFilePath }
       }
       return newEditor
     }
     await saveNormalFile(uri, content)
+    if (editor.modified) {
+      await TabModifiedStatusChange.notifyTabModifiedStatusChange(uri, false)
+    }
     return { ...newEditor, modified: false }
   } catch (error) {
     // @ts-ignore

--- a/packages/editor-worker/src/parts/TabModifiedStatusChange/TabModifiedStatusChange.ts
+++ b/packages/editor-worker/src/parts/TabModifiedStatusChange/TabModifiedStatusChange.ts
@@ -1,8 +1,8 @@
 import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
 
-export const notifyTabModifiedStatusChange = async (uri: string): Promise<void> => {
+export const notifyTabModifiedStatusChange = async (uri: string, modified: boolean): Promise<void> => {
   try {
-    await RendererWorker.invoke('Main.handleModifiedStatusChange', uri, true)
+    await RendererWorker.invoke('Main.handleModifiedStatusChange', uri, modified)
   } catch {
     // ignore
   }

--- a/packages/editor-worker/test/EditorCommandBlur.test.ts
+++ b/packages/editor-worker/test/EditorCommandBlur.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import type { EditorState } from '../src/parts/State/State.ts'
+
+const getPreferenceMock = jest.fn<(key: string) => Promise<string>>()
+const saveMock = jest.fn<(editor: EditorState) => Promise<EditorState>>()
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.ts', () => ({
+  get: getPreferenceMock,
+}))
+
+jest.unstable_mockModule('../src/parts/EditorCommand/EditorCommandSave.ts', () => ({
+  save: saveMock,
+}))
+
+const EditorCommandBlur = await import('../src/parts/EditorCommand/EditorCommandBlur.ts')
+
+beforeEach(() => {
+  getPreferenceMock.mockReset()
+  saveMock.mockReset()
+})
+
+const createEditor = (overrides: Partial<EditorState> = {}): EditorState => {
+  return {
+    focused: true,
+    modified: true,
+    ...overrides,
+  } as EditorState
+}
+
+test('handleBlur returns the editor unchanged when it is not focused', async () => {
+  const editor = createEditor({ focused: false })
+
+  const result = await EditorCommandBlur.handleBlur(editor)
+
+  expect(result).toBe(editor)
+  expect(getPreferenceMock).not.toHaveBeenCalled()
+  expect(saveMock).not.toHaveBeenCalled()
+})
+
+test('handleBlur clears focus without saving an unmodified editor', async () => {
+  const editor = createEditor({ modified: false })
+
+  const result = await EditorCommandBlur.handleBlur(editor)
+
+  expect(result).toEqual({
+    ...editor,
+    focused: false,
+  })
+  expect(getPreferenceMock).not.toHaveBeenCalled()
+  expect(saveMock).not.toHaveBeenCalled()
+})
+
+test('handleBlur does not save when auto save is off', async () => {
+  getPreferenceMock.mockResolvedValue('off')
+  const editor = createEditor()
+
+  const result = await EditorCommandBlur.handleBlur(editor)
+
+  expect(result).toEqual({
+    ...editor,
+    focused: false,
+  })
+  expect(getPreferenceMock).toHaveBeenCalledWith('files.autoSave')
+  expect(saveMock).not.toHaveBeenCalled()
+})
+
+test('handleBlur saves when auto save is enabled', async () => {
+  getPreferenceMock.mockResolvedValue('afterDelay')
+  const editor = createEditor()
+  const savedEditor = createEditor({
+    focused: false,
+    modified: false,
+  })
+  saveMock.mockResolvedValue(savedEditor)
+
+  const result = await EditorCommandBlur.handleBlur(editor)
+
+  expect(result).toBe(savedEditor)
+  expect(getPreferenceMock).toHaveBeenCalledWith('files.autoSave')
+  expect(saveMock).toHaveBeenCalledWith({
+    ...editor,
+    focused: false,
+  })
+})

--- a/packages/editor-worker/test/Save.test.ts
+++ b/packages/editor-worker/test/Save.test.ts
@@ -97,3 +97,27 @@ test('save - does not show electron message box when saving file fails outside e
   expect(result).toBe(editor)
   expect(mockRpc.invocations).toEqual([['FileSystem.writeFile', 'file:///tmp/read-only.txt', 'hello world']])
 })
+
+test('save - clears the modified status after saving', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.writeFile': async () => {},
+    'Main.handleModifiedStatusChange': async () => {},
+  })
+  const editor = {
+    lines: ['hello world'],
+    modified: true,
+    platform: PlatformType.Web,
+    uri: 'file:///tmp/example.txt',
+  }
+
+  const result = await EditorCommandSave.save(editor)
+
+  expect(result).toEqual({
+    ...editor,
+    modified: false,
+  })
+  expect(mockRpc.invocations).toEqual([
+    ['FileSystem.writeFile', 'file:///tmp/example.txt', 'hello world'],
+    ['Main.handleModifiedStatusChange', 'file:///tmp/example.txt', false],
+  ])
+})


### PR DESCRIPTION
Save modified editors on blur when files.autoSave is enabled, and clear the tab modified state after a successful save. Supersedes #1252 with preference-driven behavior.