### PR TITLE
fix: serialize editor commands

### DIFF
--- a/packages/e2e/src/editor.rapid-before-input.ts
+++ b/packages/e2e/src/editor.rapid-before-input.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-rapid-before-input'
+
+export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'baseline')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file1.txt`)
+  await Editor.setCursor(0, 8)
+
+  await Promise.all([
+    Command.execute('Editor.handleBeforeInput', 'insertText', 'a'),
+    Command.execute('Editor.handleBeforeInput', 'insertText', 'b'),
+    Command.execute('Editor.handleBeforeInput', 'insertText', 'c'),
+  ])
+
+  await Editor.shouldHaveText('baselineabc')
+}

--- a/packages/editor-worker/src/parts/WrapCommands/WrapCommands.ts
+++ b/packages/editor-worker/src/parts/WrapCommands/WrapCommands.ts
@@ -1,24 +1,34 @@
 import * as Editors from '../EditorStates/EditorStates.ts'
 import * as UpdateDerivedState from '../UpdateDerivedState/UpdateDerivedState.ts'
 
+const queues: (Promise<void> | undefined)[] = []
+
 // TODO wrap commands globally, not per editor
 // TODO only store editor state in editor worker, not in renderer worker also
 
 export const wrapCommand =
   (fn: any) =>
-  async (editorUid: number, ...args: any[]) => {
-    const oldInstance = Editors.get(editorUid)
-    const state = oldInstance.newState
-    const newEditor = await fn(state, ...args)
-    if (state === newEditor) {
-      return newEditor
+  async (uid: number, ...args: any[]) => {
+    const previous = queues[uid]
+    const { promise: next, resolve } = Promise.withResolvers<void>()
+    queues[uid] = next
+    if (previous) {
+      await previous
     }
-    const newEditorWithDerivedState = await UpdateDerivedState.updateDerivedState(state, newEditor)
-
-    // TODO if editor did not change, no need to update furthur
-
-    // TODO combine neweditor with latest editor?
-
-    Editors.set(editorUid, state, newEditorWithDerivedState)
-    return newEditorWithDerivedState
+    try {
+      const oldInstance = Editors.get(uid)
+      const state = oldInstance.newState
+      const newEditor = await fn(state, ...args)
+      if (state === newEditor) {
+        return newEditor
+      }
+      const newEditorWithDerivedState = await UpdateDerivedState.updateDerivedState(state, newEditor)
+      Editors.set(uid, state, newEditorWithDerivedState)
+      return newEditorWithDerivedState
+    } finally {
+      resolve()
+      if (queues[uid] === next) {
+        queues[uid] = undefined
+      }
+    }
   }

--- a/packages/editor-worker/test/WrapCommands.test.ts
+++ b/packages/editor-worker/test/WrapCommands.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+
+const updateDerivedStateMock = jest.fn()
+
+jest.unstable_mockModule('../src/parts/UpdateDerivedState/UpdateDerivedState.ts', () => ({
+  updateDerivedState: updateDerivedStateMock,
+}))
+
+const EditorStates = await import('../src/parts/EditorStates/EditorStates.ts')
+const WrapCommands = await import('../src/parts/WrapCommands/WrapCommands.ts')
+
+beforeEach(() => {
+  const state = {
+    text: '',
+  }
+  EditorStates.set(1, state as any, state as any)
+  updateDerivedStateMock.mockReset()
+  updateDerivedStateMock.mockImplementation(async (_oldState, newState) => {
+    await Promise.resolve()
+    return newState
+  })
+})
+
+afterEach(() => {
+  EditorStates.dispose(1)
+})
+
+test('serializes concurrent commands for the same editor', async () => {
+  const command = WrapCommands.wrapCommand((state: any, text: string) => ({
+    ...state,
+    text: state.text + text,
+  }))
+
+  await Promise.all([command(1, 'a'), command(1, 'b'), command(1, 'c')])
+
+  expect((EditorStates.get(1).newState as any).text).toBe('abc')
+})


### PR DESCRIPTION
## Summary

Serialize state-changing commands per editor so rapid input events cannot read the same state snapshot and overwrite one another.

Add a deterministic concurrent-command unit regression and an end-to-end regression that sends three rapid `beforeinput` commands and verifies all characters are retained.

## Validation

- npm run build
- npm run build:static
- npm test
- npm run type-check
- npm run lint
- focused Chromium e2e
- bundled and minified memory measurements