### PR TITLE
Apply editor settings changes live

### DIFF
--- a/packages/build/src/config.ts
+++ b/packages/build/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 852_000
+export const threshold = 854_000
 
 export const workerPath = join(root, '.tmp/dist/dist/editorWorkerMain.js')
 

--- a/packages/e2e/src/editor.settings-live-line-numbers.ts
+++ b/packages/e2e/src/editor.settings-live-line-numbers.ts
@@ -2,9 +2,13 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'editor.settings-live-line-numbers'
 
-export const test: Test = async ({ Command, expect, Locator, Main, Settings }) => {
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Settings, Workspace }) => {
   await Settings.update({ 'editor.lineNumbers': false })
-  await Main.openUri('app://settings.json')
+  const tmpDir = await FileSystem.getTmpDir()
+  const filePath = `${tmpDir}/settings-live-line-numbers.txt`
+  await FileSystem.writeFile(filePath, 'line 1\nline 2')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(filePath)
 
   const editorContent = Locator('.EditorContent')
   const gutter = Locator('.Gutter')

--- a/packages/e2e/src/editor.settings-live-line-numbers.ts
+++ b/packages/e2e/src/editor.settings-live-line-numbers.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.settings-live-line-numbers'
+
+export const test: Test = async ({ Command, expect, Locator, Main, Settings }) => {
+  await Settings.update({ 'editor.lineNumbers': false })
+  await Main.openUri('app://settings.json')
+
+  const editorContent = Locator('.EditorContent')
+  const gutter = Locator('.Gutter')
+  await expect(editorContent).toBeVisible()
+  await expect(gutter).toHaveCount(0)
+
+  await Settings.update({ 'editor.lineNumbers': true })
+  await Command.execute('Editor.handleSettingsChanged')
+  await expect(gutter).toBeVisible()
+
+  await Settings.update({ 'editor.lineNumbers': false })
+  await Command.execute('Editor.handleSettingsChanged')
+  await expect(gutter).toHaveCount(0)
+}

--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -152,6 +152,7 @@ import * as GetSelections from '../GetSelections/GetSelections.ts'
 import * as GetText from '../GetText/GetText.ts'
 import * as HandleBeforeInput from '../HandleBeforeInput/HandleBeforeInput.ts'
 import * as HandleMessagePort from '../HandleMessagePort/HandleMessagePort.ts'
+import { handleSettingsChanged } from '../HandleSettingsChanged/HandleSettingsChanged.ts'
 import * as HandleTab from '../HandleTab/HandleTab.ts'
 import { hotReload } from '../HotReload/HotReload.ts'
 import * as Initialize from '../Initialize/Initialize.ts'
@@ -283,6 +284,7 @@ export const commandMap = {
   'Editor.handleScrollBarVerticalMove': wrapCommand(EditorCommandHandleScrollBarMove.handleScrollBarVerticalPointerMove),
   'Editor.handleScrollBarVerticalPointerDown': wrapCommand(HandleScrollBarPointerDown.handleScrollBarPointerDown),
   'Editor.handleScrollBarVerticalPointerMove': wrapCommand(EditorCommandHandleScrollBarMove.handleScrollBarVerticalPointerMove),
+  'Editor.handleSettingsChanged': wrapCommand(handleSettingsChanged),
   'Editor.handleSingleClick': wrapCommand(HandleSingleClick.handleSingleClick),
   'Editor.handleTab': wrapCommand(HandleTab.handleTab),
   'Editor.handleTouchEnd': wrapCommand(HandleTouchEnd.handleTouchEnd),

--- a/packages/editor-worker/src/parts/HandleSettingsChanged/HandleSettingsChanged.ts
+++ b/packages/editor-worker/src/parts/HandleSettingsChanged/HandleSettingsChanged.ts
@@ -1,0 +1,26 @@
+import type { EditorState } from '../State/State.ts'
+import { getEditorPreferences } from '../GetEditorPreferences/GetEditorPreferences.ts'
+import * as MeasureCharacterWidth from '../MeasureCharacterWidth/MeasureCharacterWidth.ts'
+import * as Preferences from '../Preferences/Preferences.ts'
+import * as Resize from '../Resize/Resize.ts'
+
+export const handleSettingsChanged = async (state: EditorState): Promise<EditorState> => {
+  const editorPreferences = await getEditorPreferences()
+  const { diagnosticsEnabled, fontFamily, fontSize, fontWeight, letterSpacing, rowHeight } = editorPreferences
+  const [charWidth, completionsOnTypeRaw] = await Promise.all([
+    MeasureCharacterWidth.measureCharacterWidth(fontWeight, fontSize, fontFamily, letterSpacing),
+    Preferences.get('editor.completionsOnType'),
+  ])
+  const isMonospaceFont = fontFamily === 'Fira Code' || fontFamily === "'Fira Code'"
+  const editorWithUpdatedSettings: EditorState = {
+    ...state,
+    ...editorPreferences,
+    charWidth,
+    completionsOnType: Boolean(completionsOnTypeRaw),
+    diagnostics: diagnosticsEnabled ? state.diagnostics : [],
+    isMonospaceFont,
+    itemHeight: rowHeight,
+    visualDecorations: diagnosticsEnabled ? state.visualDecorations : [],
+  }
+  return Resize.resize(editorWithUpdatedSettings, {}, charWidth)
+}

--- a/packages/editor-worker/test/HandleSettingsChanged.test.ts
+++ b/packages/editor-worker/test/HandleSettingsChanged.test.ts
@@ -1,0 +1,79 @@
+import { expect, jest, test } from '@jest/globals'
+import type { EditorState } from '../src/parts/State/State.ts'
+
+const getEditorPreferences = jest.fn<() => Promise<any>>()
+const measureCharacterWidth = jest.fn<(fontWeight: number, fontSize: number, fontFamily: string, letterSpacing: number) => Promise<number>>()
+const getPreference = jest.fn<(key: string) => Promise<any>>()
+
+jest.unstable_mockModule('../src/parts/GetEditorPreferences/GetEditorPreferences.ts', () => ({
+  getEditorPreferences,
+}))
+
+jest.unstable_mockModule('../src/parts/MeasureCharacterWidth/MeasureCharacterWidth.ts', () => ({
+  measureCharacterWidth,
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.ts', () => ({
+  get: getPreference,
+}))
+
+const { handleSettingsChanged } = await import('../src/parts/HandleSettingsChanged/HandleSettingsChanged.ts')
+
+test('handleSettingsChanged reloads editor preferences and geometry', async () => {
+  getEditorPreferences.mockResolvedValue({
+    completionTriggerCharacters: ['.'],
+    diagnosticsEnabled: false,
+    fontFamily: 'Fira Code',
+    fontSize: 16,
+    fontWeight: 500,
+    isAutoClosingBracketsEnabled: true,
+    isAutoClosingQuotesEnabled: true,
+    isAutoClosingTagsEnabled: true,
+    isQuickSuggestionsEnabled: true,
+    letterSpacing: 1,
+    lineNumbers: false,
+    rowHeight: 24,
+    tabSize: 4,
+  })
+  measureCharacterWidth.mockResolvedValue(10)
+  getPreference.mockResolvedValue(true)
+  const state = {
+    columnWidth: 9,
+    deltaY: 40,
+    diagnostics: [{ message: 'problem' }],
+    height: 48,
+    itemHeight: 20,
+    lines: ['one', 'two', 'three', 'four'],
+    minimumSliderSize: 20,
+    rowHeight: 20,
+    visualDecorations: [{ className: 'DiagnosticError' }],
+    width: 800,
+    x: 0,
+    y: 0,
+  } as unknown as EditorState
+
+  const result = await handleSettingsChanged(state)
+
+  expect(measureCharacterWidth).toHaveBeenCalledWith(500, 16, 'Fira Code', 1)
+  expect(getPreference).toHaveBeenCalledWith('editor.completionsOnType')
+  expect(result).toEqual(
+    expect.objectContaining({
+      charWidth: 10,
+      columnWidth: 10,
+      completionsOnType: true,
+      diagnostics: [],
+      fontFamily: 'Fira Code',
+      fontSize: 16,
+      fontWeight: 500,
+      isMonospaceFont: true,
+      itemHeight: 24,
+      letterSpacing: 1,
+      lineNumbers: false,
+      maxLineY: 3,
+      minLineY: 1,
+      rowHeight: 24,
+      tabSize: 4,
+      visualDecorations: [],
+    }),
+  )
+})


### PR DESCRIPTION
Adds an editor settings-change hook that reloads current preferences, recomputes editor geometry, and rerenders open editors. Includes focused unit coverage and an e2e regression for live line-number toggling.