### PR TITLE
fix: detect languages by file name

### DIFF
--- a/packages/editor-worker/src/parts/GetLanguageId/GetLanguageId.ts
+++ b/packages/editor-worker/src/parts/GetLanguageId/GetLanguageId.ts
@@ -21,6 +21,11 @@ const getLanguageByFileName = (languages: readonly any[], fileNameLower: string)
   return ''
 }
 
+const getFileName = (uri: string): string => {
+  const slashIndex = Math.max(uri.lastIndexOf('/'), uri.lastIndexOf('\\'))
+  return uri.slice(slashIndex + 1)
+}
+
 export const getLanguageId = (uri: string, languages: readonly any[]): string => {
   Assert.string(uri)
   // TODO this is inefficient for icon theme, as file extension is computed twice
@@ -33,7 +38,7 @@ export const getLanguageId = (uri: string, languages: readonly any[]): string =>
   if (candidate1) {
     return candidate1
   }
-  const fileNameLower = uri.toLowerCase()
+  const fileNameLower = getFileName(uri).toLowerCase()
   const secondExtensionIndex = GetFileExtension.getNthFileExtension(uri, extensionIndex - 1)
   const secondExtension = uri.slice(secondExtensionIndex)
   const candidate2 = getLanguageByExtension(languages, secondExtension)

--- a/packages/editor-worker/test/GetLanguageId.test.ts
+++ b/packages/editor-worker/test/GetLanguageId.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@jest/globals'
+import * as GetLanguageId from '../src/parts/GetLanguageId/GetLanguageId.ts'
+
+test('getLanguageId - file name in uri', () => {
+  const languages = [
+    {
+      id: 'dotenv',
+      extensions: ['.env'],
+      fileNames: ['.env.sample'],
+    },
+  ]
+
+  expect(GetLanguageId.getLanguageId('file:///workspace/.env.sample', languages)).toBe('dotenv')
+})
+
+test('getLanguageId - Windows file name', () => {
+  const languages = [
+    {
+      id: 'dotenv',
+      extensions: ['.env'],
+      fileNames: ['.env.sample'],
+    },
+  ]
+
+  expect(GetLanguageId.getLanguageId('C:\\workspace\\.env.sample', languages)).toBe('dotenv')
+})

--- a/packages/editor-worker/test/GetLanguageId.test.ts
+++ b/packages/editor-worker/test/GetLanguageId.test.ts
@@ -4,9 +4,9 @@ import * as GetLanguageId from '../src/parts/GetLanguageId/GetLanguageId.ts'
 test('getLanguageId - file name in uri', () => {
   const languages = [
     {
-      id: 'dotenv',
       extensions: ['.env'],
       fileNames: ['.env.sample'],
+      id: 'dotenv',
     },
   ]
 
@@ -16,9 +16,9 @@ test('getLanguageId - file name in uri', () => {
 test('getLanguageId - Windows file name', () => {
   const languages = [
     {
-      id: 'dotenv',
       extensions: ['.env'],
       fileNames: ['.env.sample'],
+      id: 'dotenv',
     },
   ]
 


### PR DESCRIPTION
Fix exact file-name language associations by matching against the basename instead of the full URI.

This makes `.env.sample` resolve to the dotenv language when opened from a workspace path.