### PR TITLE
fix: retarget editor after file rename

### DIFF
--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -75,6 +75,7 @@ import * as HandleTouchEnd from '../EditorCommand/EditorCommandHandleTouchEnd.ts
 import * as HandleTouchMove from '../EditorCommand/EditorCommandHandleTouchMove.ts'
 import * as HandleTouchStart from '../EditorCommand/EditorCommandHandleTouchStart.ts'
 import * as HandleTripleClick from '../EditorCommand/EditorCommandHandleTripleClick.ts'
+import { handleUriChange } from '../EditorCommand/EditorCommandHandleUriChange.ts'
 import * as HandleWheel from '../EditorCommand/EditorCommandHandleWheel.ts'
 import * as IndentLess from '../EditorCommand/EditorCommandIndentLess.ts'
 import * as IndentMore from '../EditorCommand/EditorCommandIndentMore.ts'
@@ -291,6 +292,7 @@ export const commandMap = {
   'Editor.handleTouchMove': wrapCommand(HandleTouchMove.handleTouchMove),
   'Editor.handleTouchStart': wrapCommand(HandleTouchStart.handleTouchStart),
   'Editor.handleTripleClick': wrapCommand(HandleTripleClick.handleTripleClick),
+  'Editor.handleUriChange': wrapCommand(handleUriChange),
   'Editor.handleWheel': wrapCommand(HandleWheel.handleWheel),
   'Editor.hotReload': hotReload,
   'Editor.indendLess': wrapCommand(IndentLess.indentLess),

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandHandleUriChange.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandHandleUriChange.ts
@@ -1,0 +1,13 @@
+import type { EditorState } from '../State/State.ts'
+import * as ExtensionHostCommandType from '../ExtensionHostCommandType/ExtensionHostCommandType.ts'
+import * as ExtensionHostWorker from '../ExtensionHostWorker/ExtensionHostWorker.ts'
+import * as TextDocument from '../TextDocument/TextDocument.ts'
+
+export const handleUriChange = async (editor: EditorState, newUri: string): Promise<EditorState> => {
+  const content = TextDocument.getText(editor)
+  await ExtensionHostWorker.invoke(ExtensionHostCommandType.TextDocumentSyncFull, newUri, editor.id, editor.languageId, content)
+  return {
+    ...editor,
+    uri: newUri,
+  }
+}

--- a/packages/editor-worker/test/EditorCommandHandleUriChange.test.ts
+++ b/packages/editor-worker/test/EditorCommandHandleUriChange.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@jest/globals'
+import { ExtensionHost } from '@lvce-editor/rpc-registry'
+import { handleUriChange } from '../src/parts/EditorCommand/EditorCommandHandleUriChange.ts'
+
+test('handleUriChange retargets the editor and extension host document without changing content', async () => {
+  using mockRpc = ExtensionHost.registerMockRpc({
+    'ExtensionHostTextDocument.syncFull'() {},
+  })
+  const editor = {
+    id: 42,
+    languageId: 'plaintext',
+    lines: ['hello', 'world'],
+    modified: true,
+    uri: '/test/original.txt',
+  }
+
+  const result = await handleUriChange(editor as any, '/test/renamed.txt')
+
+  expect(result).toEqual({
+    ...editor,
+    uri: '/test/renamed.txt',
+  })
+  expect(mockRpc.invocations).toEqual([['ExtensionHostTextDocument.syncFull', '/test/renamed.txt', 42, 'plaintext', 'hello\nworld']])
+})


### PR DESCRIPTION
## Summary

- add an editor command that updates a live document URI without replacing its in-memory content
- resynchronize the extension-host text document under the renamed URI
- add regression unit coverage for modified content preservation