### PR TITLE
fix: replace complete next occurrence selections

### DIFF
--- a/packages/e2e/src/editor.select-next-occurrence-reversed-selection.ts
+++ b/packages/e2e/src/editor.select-next-occurrence-reversed-selection.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-select-next-occurrence-reversed-selection'
+
+export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file1.txt`
+  await FileSystem.writeFile(uri, 'foo foo\nfoo')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Editor.setSelections(new Uint32Array([0, 3, 0, 0]))
+
+  await Editor.selectNextOccurrence()
+  await Editor.shouldHaveSelections(new Uint32Array([0, 3, 0, 0, 0, 4, 0, 7]))
+  await Command.execute('Editor.pasteText', 'X')
+
+  await Editor.shouldHaveText('X X\nfoo')
+  await Editor.shouldHaveSelections(new Uint32Array([0, 1, 0, 1, 0, 3, 0, 3]))
+}

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandReplaceRange.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandReplaceRange.ts
@@ -3,20 +3,28 @@ import * as TextDocument from '../TextDocument/TextDocument.ts'
 
 export const replaceRange = (editor: any, ranges: any, replacement: any, origin: any) => {
   const changes: any[] = []
+  const columnDeltas = new Map<number, number>()
   const rangesLength = ranges.length
   for (let i = 0; i < rangesLength; i += 4) {
     const [selectionStartRow, selectionStartColumn, selectionEndRow, selectionEndColumn] = GetSelectionPairs.getSelectionPairs(ranges, i)
+    const columnDelta = selectionStartRow === selectionEndRow ? (columnDeltas.get(selectionStartRow) ?? 0) : 0
     const start = {
-      columnIndex: selectionStartColumn,
+      columnIndex: selectionStartColumn + columnDelta,
       rowIndex: selectionStartRow,
     }
     const end = {
-      columnIndex: selectionEndColumn,
+      columnIndex: selectionEndColumn + columnDelta,
       rowIndex: selectionEndRow,
     }
     const selection = {
-      end,
-      start,
+      end: {
+        columnIndex: selectionEndColumn,
+        rowIndex: selectionEndRow,
+      },
+      start: {
+        columnIndex: selectionStartColumn,
+        rowIndex: selectionStartRow,
+      },
     }
     changes.push({
       deleted: TextDocument.getSelectionText(editor, selection),
@@ -25,6 +33,14 @@ export const replaceRange = (editor: any, ranges: any, replacement: any, origin:
       origin,
       start: start,
     })
+    if (selectionStartRow === selectionEndRow) {
+      if (replacement.length <= 1) {
+        const insertedLength = replacement[0]?.length ?? 0
+        columnDeltas.set(selectionStartRow, columnDelta + insertedLength - (selectionEndColumn - selectionStartColumn))
+      } else {
+        columnDeltas.set(selectionStartRow, replacement.at(-1).length - selectionEndColumn)
+      }
+    }
   }
   return changes
 }

--- a/packages/editor-worker/src/parts/GetSelectNextOccurrenceResult/GetSelectNextOccurrenceResult.ts
+++ b/packages/editor-worker/src/parts/GetSelectNextOccurrenceResult/GetSelectNextOccurrenceResult.ts
@@ -23,9 +23,7 @@ import * as GetWordMatchAtPosition from '../GetWordMatchAtPosition/GetWordMatchA
 
 const getSelectionEditsSingleLineWord = (lines: string[], selections: any) => {
   const lastSelectionIndex = selections.length - 4
-  const rowIndex = selections[lastSelectionIndex]
-  const lastSelectionStartColumnIndex = selections[lastSelectionIndex + 1]
-  const lastSelectionEndColumnIndex = selections[lastSelectionIndex + 3]
+  const [rowIndex, lastSelectionStartColumnIndex, , lastSelectionEndColumnIndex] = GetSelectionPairs.getSelectionPairs(selections, lastSelectionIndex)
   const line = lines[rowIndex]
   const word = line.slice(lastSelectionStartColumnIndex, lastSelectionEndColumnIndex)
   const columnIndexAfter = line.indexOf(word, lastSelectionEndColumnIndex)

--- a/packages/editor-worker/test/EditorCommandReplaceRange.test.ts
+++ b/packages/editor-worker/test/EditorCommandReplaceRange.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@jest/globals'
+import * as EditorCommandReplaceRange from '../src/parts/EditorCommand/EditorCommandReplaceRange.ts'
+import * as EditorSelection from '../src/parts/EditorSelection/EditorSelection.ts'
+import * as TextDocument from '../src/parts/TextDocument/TextDocument.ts'
+
+test('replaceRange - adjusts later replacements on the same line', () => {
+  const editor = {
+    lines: ['foo foo', 'foo'],
+  }
+  const ranges = EditorSelection.fromRanges([0, 3, 0, 0], [0, 4, 0, 7])
+  const changes = EditorCommandReplaceRange.replaceRange(editor, ranges, ['X'], 'paste')
+
+  expect(changes).toEqual([
+    {
+      deleted: ['foo'],
+      end: { columnIndex: 3, rowIndex: 0 },
+      inserted: ['X'],
+      origin: 'paste',
+      start: { columnIndex: 0, rowIndex: 0 },
+    },
+    {
+      deleted: ['foo'],
+      end: { columnIndex: 5, rowIndex: 0 },
+      inserted: ['X'],
+      origin: 'paste',
+      start: { columnIndex: 2, rowIndex: 0 },
+    },
+  ])
+  expect(TextDocument.applyEdits(editor, changes)).toEqual(['X X', 'foo'])
+})

--- a/packages/editor-worker/test/EditorSelectNextOccurrence.test.ts
+++ b/packages/editor-worker/test/EditorSelectNextOccurrence.test.ts
@@ -92,6 +92,22 @@ test('editorSelectNextOccurrence - one selection and more selections possible af
   expect(newEditor.selections).toEqual(EditorSelection.fromRanges([0, 0, 0, 4], [1, 0, 1, 4]))
 })
 
+test('editorSelectNextOccurrence - reversed selection and more selections possible after', () => {
+  const editor = {
+    finalDeltaY: 1000,
+    lineCache: [],
+    lines: ['foo foo', 'foo'],
+    maxLineY: 1000,
+    minLineY: 0,
+    primarySelectionIndex: 0,
+    rowHeight: 20,
+    selections: EditorSelection.fromRange(0, 3, 0, 0),
+    width: 1000,
+  }
+  const newEditor = EditorSelectNextOccurrence.selectNextOccurrence(editor)
+  expect(newEditor.selections).toEqual(EditorSelection.fromRanges([0, 3, 0, 0], [0, 4, 0, 7]))
+})
+
 test('editorSelectNextOccurrence - one selection and more selections possible before', () => {
   const editor = {
     finalDeltaY: 1000,


### PR DESCRIPTION
## Summary

- normalize reversed selections before finding the next occurrence
- adjust later same-line selection replacements after earlier edits change the line length
- add unit and browser E2E regressions for reversed Add Next Occurrence followed by paste

## Verification

- editor-worker: 157 suites passed, 494 tests passed
- editor-worker and E2E type checks passed
- targeted ESLint, Prettier, and diff checks passed
- new select-next-occurrence browser E2E passed
- existing multi-cursor paste and typing browser E2Es passed

## Manual report

Resolves the manual-testing report add-next-occurrence-selects-only-last-character.