### PR TITLE
fix: dismiss completion widget

### DIFF
--- a/packages/build/src/config.ts
+++ b/packages/build/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 854_000
+export const threshold = 856_000
 
 export const workerPath = join(root, '.tmp/dist/dist/editorWorkerMain.js')
 

--- a/packages/e2e/src/editor.completion-dismiss-on-editor-switch.ts
+++ b/packages/e2e/src/editor.completion-dismiss-on-editor-switch.ts
@@ -1,22 +1,24 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'editor.completion-dismiss'
+export const name = 'editor.completion-dismiss-on-editor-switch'
 
-export const test: Test = async ({ Editor, expect, Extension, FileSystem, KeyBoard, Locator, Main, Workspace }) => {
+export const test: Test = async ({ Editor, expect, Extension, FileSystem, Locator, Main, Workspace }) => {
   const extensionUri = import.meta.resolve('../fixtures/editor.completion-one-result')
   await Extension.addWebExtension(extensionUri)
   const tmpDir = await FileSystem.getTmpDir()
-  const file = `${tmpDir}/file.xyz`
-  await FileSystem.writeFile(file, 'content')
+  const firstFile = `${tmpDir}/first.xyz`
+  const secondFile = `${tmpDir}/second.xyz`
+  await FileSystem.writeFile(firstFile, 'content 1')
+  await FileSystem.writeFile(secondFile, 'content 2')
   await Workspace.setPath(tmpDir)
-  await Main.openUri(file)
+  await Main.openUri(firstFile)
   await Editor.setCursor(0, 0)
 
   const completions = Locator('.EditorCompletion')
   await Editor.openCompletion()
   await expect(completions).toBeVisible()
 
-  await KeyBoard.press('Escape')
+  await Main.openUri(secondFile)
 
   await expect(completions).toBeHidden()
 }

--- a/packages/e2e/src/editor.completion-dismiss.ts
+++ b/packages/e2e/src/editor.completion-dismiss.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.completion-dismiss'
+
+export const test: Test = async ({ Editor, expect, Extension, FileSystem, KeyBoard, Locator, Main, Workspace }) => {
+  const extensionUri = import.meta.resolve('../fixtures/editor.completion-one-result')
+  await Extension.addWebExtension(extensionUri)
+  const tmpDir = await FileSystem.getTmpDir()
+  const firstFile = `${tmpDir}/first.xyz`
+  const secondFile = `${tmpDir}/second.xyz`
+  await FileSystem.writeFile(firstFile, 'content 1')
+  await FileSystem.writeFile(secondFile, 'content 2')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(firstFile)
+  await Editor.setCursor(0, 0)
+
+  const completions = Locator('.EditorCompletion')
+  await Editor.openCompletion()
+  await expect(completions).toBeVisible()
+
+  await KeyBoard.press('Escape')
+
+  await expect(completions).toBeHidden()
+
+  await Editor.openCompletion()
+  await expect(completions).toBeVisible()
+
+  await Main.openUri(secondFile)
+
+  await expect(completions).toBeHidden()
+}

--- a/packages/editor-worker/src/parts/CloseWidgetsMaybe/CloseWidgetsMaybe.ts
+++ b/packages/editor-worker/src/parts/CloseWidgetsMaybe/CloseWidgetsMaybe.ts
@@ -7,5 +7,5 @@ export const closeWidgetsMaybe = (widgets: readonly any[]): readonly any[] => {
   if (widgets.length === 0) {
     return widgets
   }
-  return widgets.filter(isPersistentWidget)
+  return widgets.filter((widget) => isPersistentWidget(widget.id))
 }

--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -15,6 +15,7 @@ import * as EditorBlur from '../EditorCommand/EditorCommandBlur.ts'
 import * as EditorBraceCompletion from '../EditorCommand/EditorCommandBraceCompletion.ts'
 import * as CancelSelection from '../EditorCommand/EditorCommandCancelSelection.ts'
 import * as EditorCommandCloseCodeGenerator from '../EditorCommand/EditorCommandCloseCodeGenerator.ts'
+import * as EditorCommandCloseCompletion from '../EditorCommand/EditorCommandCloseCompletion.ts'
 import * as EditorCommandCloseFind from '../EditorCommand/EditorCommandCloseFind.ts'
 import * as CloseRename from '../EditorCommand/EditorCommandCloseRename.ts'
 import * as EditorCommandCloseSourceAction from '../EditorCommand/EditorCommandCloseSourceAction.ts'
@@ -189,6 +190,7 @@ export const commandMap = {
   'Editor.cancelSelection': wrapCommand(CancelSelection.cancelSelection),
   'Editor.closeCodeGenerator': wrapCommand(EditorCommandCloseCodeGenerator.closeCodeGenerator),
   'Editor.closeColorPicker': wrapCommand(EditorOpenColorPicker.closeColorPicker),
+  'Editor.closeCompletion': wrapCommand(EditorCommandCloseCompletion.closeCompletion),
   'Editor.closeFind': wrapCommand(EditorCommandCloseFind.closeFind),
   'Editor.closeFind2': ExternalGetPositionAtCursor.closeFind2,
   'Editor.closeRename': wrapCommand(CloseRename.closeRename),

--- a/packages/editor-worker/src/parts/DiffAdditionalFocus/DiffAdditionalFocus.ts
+++ b/packages/editor-worker/src/parts/DiffAdditionalFocus/DiffAdditionalFocus.ts
@@ -1,0 +1,5 @@
+import type { EditorState } from '../State/State.ts'
+
+export const isEqual = (oldState: EditorState, newState: EditorState): boolean => {
+  return oldState.additionalFocus === newState.additionalFocus
+}

--- a/packages/editor-worker/src/parts/DiffModules/DiffModules.ts
+++ b/packages/editor-worker/src/parts/DiffModules/DiffModules.ts
@@ -1,9 +1,17 @@
+import * as DiffAdditionalFocus from '../DiffAdditionalFocus/DiffAdditionalFocus.ts'
 import * as DiffCss from '../DiffCss/DiffCss.ts'
 import * as DiffFocus from '../DiffFocus/DiffFocus.ts'
 import * as DiffItems from '../DiffItems/DiffItems.ts'
 import * as DiffType from '../DiffType/DiffType.ts'
 import * as DiffWidgets from '../DiffWidgets/DiffWidgets.ts'
 
-export const modules = [DiffItems.isEqual, DiffFocus.isEqual, DiffFocus.isEqual, DiffCss.isEqual, DiffWidgets.isEqual]
+export const modules = [DiffItems.isEqual, DiffFocus.isEqual, DiffFocus.isEqual, DiffAdditionalFocus.isEqual, DiffCss.isEqual, DiffWidgets.isEqual]
 
-export const numbers = [DiffType.RenderIncremental, DiffType.RenderFocus, DiffType.RenderFocusContext, DiffType.RenderCss, DiffType.RenderWidgets]
+export const numbers = [
+  DiffType.RenderIncremental,
+  DiffType.RenderFocus,
+  DiffType.RenderFocusContext,
+  DiffType.RenderAdditionalFocusContext,
+  DiffType.RenderCss,
+  DiffType.RenderWidgets,
+]

--- a/packages/editor-worker/src/parts/DiffType/DiffType.ts
+++ b/packages/editor-worker/src/parts/DiffType/DiffType.ts
@@ -4,3 +4,4 @@ export const RenderFocusContext = 7
 export const RenderCss = 11
 export const RenderIncremental = 12
 export const RenderWidgets = 13
+export const RenderAdditionalFocusContext = 14

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandBlur.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandBlur.ts
@@ -1,4 +1,5 @@
 import type { EditorState } from '../State/State.ts'
+import * as CloseWidgetsMaybe from '../CloseWidgetsMaybe/CloseWidgetsMaybe.ts'
 import * as Preferences from '../Preferences/Preferences.ts'
 import * as EditorCommandSave from './EditorCommandSave.ts'
 
@@ -8,7 +9,9 @@ export const handleBlur = async (editor: EditorState): Promise<EditorState> => {
   }
   const newEditor = {
     ...editor,
+    additionalFocus: 0,
     focused: false,
+    widgets: CloseWidgetsMaybe.closeWidgetsMaybe(editor.widgets || []),
   }
   if (!editor.modified) {
     return newEditor

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandCloseCompletion.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandCloseCompletion.ts
@@ -1,0 +1,15 @@
+import { WidgetId } from '@lvce-editor/constants'
+import * as RemoveEditorWidget from '../RemoveEditorWidget/RemoveEditorWidget.ts'
+
+export const closeCompletion = (editor: any) => {
+  const { widgets } = editor
+  if (widgets.every((widget: any) => widget.id !== WidgetId.Completion)) {
+    return editor
+  }
+  return {
+    ...editor,
+    additionalFocus: 0,
+    focused: true,
+    widgets: RemoveEditorWidget.removeEditorWidget(widgets, WidgetId.Completion),
+  }
+}

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -144,7 +144,7 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusEditorCompletions,
     },
     {
-      command: 'EditorCompletion.close',
+      command: 'Editor.closeCompletion',
       key: KeyCode.Escape,
       when: WhenExpression.FocusEditorCompletions,
     },

--- a/packages/editor-worker/src/parts/GetRenderer/GetRenderer.ts
+++ b/packages/editor-worker/src/parts/GetRenderer/GetRenderer.ts
@@ -1,5 +1,6 @@
 import type { Renderer } from '../Renderer/Renderer.ts'
 import * as DiffType from '../DiffType/DiffType.ts'
+import * as RenderAdditionalFocusContext from '../RenderAdditionalFocusContext/RenderAdditionalFocusContext.ts'
 import { renderCss } from '../RenderCss/RenderCss.ts'
 import { renderFocus } from '../RenderFocus/RenderFocus.ts'
 import * as RenderFocusContext from '../RenderFocusContext/RenderFocusContext.ts'
@@ -8,6 +9,8 @@ import { renderWidgets } from '../RenderWidgets/RenderWidgets.ts'
 
 export const getRenderer = (diffType: number): Renderer => {
   switch (diffType) {
+    case DiffType.RenderAdditionalFocusContext:
+      return RenderAdditionalFocusContext.renderAdditionalFocusContext
     case DiffType.RenderCss:
       return renderCss
     case DiffType.RenderFocus:

--- a/packages/editor-worker/src/parts/RenderAdditionalFocusContext/RenderAdditionalFocusContext.ts
+++ b/packages/editor-worker/src/parts/RenderAdditionalFocusContext/RenderAdditionalFocusContext.ts
@@ -1,0 +1,8 @@
+import type { EditorState } from '../State/State.ts'
+
+export const renderAdditionalFocusContext = (oldState: EditorState, newState: EditorState): readonly any[] => {
+  if (newState.additionalFocus) {
+    return ['Viewlet.setAdditionalFocus', newState.uid, newState.additionalFocus]
+  }
+  return ['Viewlet.unsetAdditionalFocus', newState.uid, oldState.additionalFocus]
+}

--- a/packages/editor-worker/src/parts/RenderEditor/RenderEditor.ts
+++ b/packages/editor-worker/src/parts/RenderEditor/RenderEditor.ts
@@ -66,7 +66,7 @@ const renderAdditionalFocusContext = {
     if (newState.additionalFocus) {
       return ['Viewlet.setAdditionalFocus', newState.uid, newState.additionalFocus]
     }
-    return ['viewlet.unsetAdditionalFocus', newState.uid, newState.additionalFocus]
+    return ['Viewlet.unsetAdditionalFocus', newState.uid, oldState.additionalFocus]
   },
   isEqual: (oldState: EditorState, newState: EditorState) => oldState.additionalFocus === newState.additionalFocus,
 }

--- a/packages/editor-worker/src/parts/RenderEditor/RenderEditor.ts
+++ b/packages/editor-worker/src/parts/RenderEditor/RenderEditor.ts
@@ -1,5 +1,6 @@
 import { ViewletCommand } from '@lvce-editor/constants'
 import type { EditorState } from '../State/State.ts'
+import * as DiffAdditionalFocus from '../DiffAdditionalFocus/DiffAdditionalFocus.ts'
 import * as DiffCss from '../DiffCss/DiffCss.ts'
 import * as Editors from '../EditorStates/EditorStates.ts'
 import { emptyIncrementalEdits } from '../EmptyIncrementalEdits/EmptyIncrementalEdits.ts'
@@ -8,6 +9,7 @@ import * as GetDiagnosticsVirtualDom from '../GetDiagnosticsVirtualDom/GetDiagno
 import * as GetEditorGutterVirtualDom from '../GetEditorGutterVirtualDom/GetEditorGutterVirtualDom.ts'
 import * as GetEditorRowsVirtualDom from '../GetEditorRowsVirtualDom/GetEditorRowsVirtualDom.ts'
 import * as GetSelectionsVirtualDom from '../GetSelectionsVirtualDom/GetSelectionsVirtualDom.ts'
+import * as RenderAdditionalFocusContext from '../RenderAdditionalFocusContext/RenderAdditionalFocusContext.ts'
 import { renderCss as renderCssCommand } from '../RenderCss/RenderCss.ts'
 import { renderWidgets as renderWidgetsCommand } from '../RenderWidgets/RenderWidgets.ts'
 
@@ -62,13 +64,8 @@ const renderFocusContext = {
 }
 
 const renderAdditionalFocusContext = {
-  apply(oldState: EditorState, newState: EditorState) {
-    if (newState.additionalFocus) {
-      return ['Viewlet.setAdditionalFocus', newState.uid, newState.additionalFocus]
-    }
-    return ['Viewlet.unsetAdditionalFocus', newState.uid, oldState.additionalFocus]
-  },
-  isEqual: (oldState: EditorState, newState: EditorState) => oldState.additionalFocus === newState.additionalFocus,
+  apply: RenderAdditionalFocusContext.renderAdditionalFocusContext,
+  isEqual: DiffAdditionalFocus.isEqual,
 }
 
 const renderDecorations = {

--- a/packages/editor-worker/test/CloseWidgetsMaybe.test.ts
+++ b/packages/editor-worker/test/CloseWidgetsMaybe.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import { WidgetId } from '@lvce-editor/constants'
+import * as CloseWidgetsMaybe from '../src/parts/CloseWidgetsMaybe/CloseWidgetsMaybe.ts'
+
+test('closeWidgetsMaybe keeps persistent widgets and closes transient widgets', () => {
+  const findWidget = { id: WidgetId.Find }
+  const completionWidget = { id: WidgetId.Completion }
+
+  expect(CloseWidgetsMaybe.closeWidgetsMaybe([findWidget, completionWidget])).toEqual([findWidget])
+})
+
+test('closeWidgetsMaybe preserves an empty widget array', () => {
+  const widgets: readonly any[] = []
+
+  expect(CloseWidgetsMaybe.closeWidgetsMaybe(widgets)).toBe(widgets)
+})

--- a/packages/editor-worker/test/DiffAdditionalFocus.test.ts
+++ b/packages/editor-worker/test/DiffAdditionalFocus.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import * as Diff from '../src/parts/Diff/Diff.ts'
+import * as DiffType from '../src/parts/DiffType/DiffType.ts'
+
+test('diff includes additional focus context changes', () => {
+  const oldState = {
+    additionalFocus: 0,
+  }
+  const newState = {
+    additionalFocus: 9,
+  }
+
+  expect(Diff.diff(oldState as any, newState as any)).toContain(DiffType.RenderAdditionalFocusContext)
+})

--- a/packages/editor-worker/test/EditorCommandBlur.test.ts
+++ b/packages/editor-worker/test/EditorCommandBlur.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { WidgetId } from '@lvce-editor/constants'
 import type { EditorState } from '../src/parts/State/State.ts'
 
 const getPreferenceMock = jest.fn<(key: string) => Promise<string>>()
@@ -21,8 +22,10 @@ beforeEach(() => {
 
 const createEditor = (overrides: Partial<EditorState> = {}): EditorState => {
   return {
+    additionalFocus: 0,
     focused: true,
     modified: true,
+    widgets: [],
     ...overrides,
   } as EditorState
 }
@@ -48,6 +51,25 @@ test('handleBlur clears focus without saving an unmodified editor', async () => 
   })
   expect(getPreferenceMock).not.toHaveBeenCalled()
   expect(saveMock).not.toHaveBeenCalled()
+})
+
+test('handleBlur closes transient widgets and clears additional focus', async () => {
+  const completionWidget = { id: WidgetId.Completion }
+  const findWidget = { id: WidgetId.Find }
+  const editor = createEditor({
+    additionalFocus: 9,
+    modified: false,
+    widgets: [completionWidget, findWidget],
+  })
+
+  const result = await EditorCommandBlur.handleBlur(editor)
+
+  expect(result).toEqual({
+    ...editor,
+    additionalFocus: 0,
+    focused: false,
+    widgets: [findWidget],
+  })
 })
 
 test('handleBlur does not save when auto save is off', async () => {

--- a/packages/editor-worker/test/EditorCommandCloseCompletion.test.ts
+++ b/packages/editor-worker/test/EditorCommandCloseCompletion.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@jest/globals'
+import { WidgetId } from '@lvce-editor/constants'
+import * as EditorCommandCloseCompletion from '../src/parts/EditorCommand/EditorCommandCloseCompletion.ts'
+
+test('closeCompletion removes the completion widget and its additional focus', () => {
+  const editor = {
+    additionalFocus: 9,
+    focused: true,
+    widgets: [
+      {
+        id: WidgetId.Completion,
+        newState: { uid: 2 },
+        oldState: { uid: 2 },
+      },
+    ],
+  }
+
+  expect(EditorCommandCloseCompletion.closeCompletion(editor)).toEqual({
+    ...editor,
+    additionalFocus: 0,
+    widgets: [],
+  })
+})
+
+test('closeCompletion returns the editor unchanged when completion is not open', () => {
+  const editor = {
+    additionalFocus: 0,
+    focused: true,
+    widgets: [],
+  }
+
+  expect(EditorCommandCloseCompletion.closeCompletion(editor)).toBe(editor)
+})

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -10,3 +10,11 @@ test('Escape closes the focused color picker', () => {
     when: WhenExpression.FocusColorPicker,
   })
 })
+
+test('Escape closes focused editor completions', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.closeCompletion',
+    key: KeyCode.Escape,
+    when: WhenExpression.FocusEditorCompletions,
+  })
+})

--- a/packages/editor-worker/test/RenderAdditionalFocusContext.test.ts
+++ b/packages/editor-worker/test/RenderAdditionalFocusContext.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import * as RenderAdditionalFocusContext from '../src/parts/RenderAdditionalFocusContext/RenderAdditionalFocusContext.ts'
+
+test('renderAdditionalFocusContext sets additional focus', () => {
+  const oldState = { additionalFocus: 0, uid: 1 }
+  const newState = { additionalFocus: 9, uid: 1 }
+
+  expect(RenderAdditionalFocusContext.renderAdditionalFocusContext(oldState as any, newState as any)).toEqual(['Viewlet.setAdditionalFocus', 1, 9])
+})
+
+test('renderAdditionalFocusContext removes the previous additional focus', () => {
+  const oldState = { additionalFocus: 9, uid: 1 }
+  const newState = { additionalFocus: 0, uid: 1 }
+
+  expect(RenderAdditionalFocusContext.renderAdditionalFocusContext(oldState as any, newState as any)).toEqual(['Viewlet.unsetAdditionalFocus', 1, 9])
+})

--- a/packages/editor-worker/test/RenderEditorAdditionalFocus.test.ts
+++ b/packages/editor-worker/test/RenderEditorAdditionalFocus.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@jest/globals'
+import * as EditorStates from '../src/parts/EditorStates/EditorStates.ts'
+import * as RenderEditor from '../src/parts/RenderEditor/RenderEditor.ts'
+
+test('renderEditor removes the previous additional focus context', async () => {
+  const uid = 910_001
+  const sharedState = {
+    cursorInfos: [],
+    focus: 12,
+    focused: true,
+    isSelecting: false,
+    lineNumbers: false,
+    selectionInfos: [],
+    uid,
+    widgets: [],
+  }
+  const oldState = {
+    ...sharedState,
+    additionalFocus: 9,
+  }
+  const newState = {
+    ...sharedState,
+    additionalFocus: 0,
+  }
+  EditorStates.set(uid, oldState as any, newState as any)
+
+  await expect(RenderEditor.renderEditor(uid)).resolves.toEqual([['Viewlet.unsetAdditionalFocus', uid, 9]])
+
+  EditorStates.dispose(uid)
+})


### PR DESCRIPTION
Fix completion dismissal with Escape and close transient editor widgets when focus moves to another editor.

Add regression coverage for Escape, tab switching, widget focus cleanup, and transient widget disposal.