### PR TITLE
fix: preserve CRLF line endings

### DIFF
--- a/packages/e2e/src/editor.crlf-line-end-editing.ts
+++ b/packages/e2e/src/editor.crlf-line-end-editing.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.crlf-line-end-editing'
+
+export const test: Test = async ({ Editor, FileSystem, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const filePath = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(filePath, 'first\r\nsecond\r\n')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(filePath)
+  await Editor.setCursor(0, 0)
+
+  await Editor.cursorEnd()
+
+  await Editor.shouldHaveSelections(new Uint32Array([0, 5, 0, 5]))
+
+  await Editor.type('Q')
+  await Main.save()
+
+  await FileSystem.shouldHaveFile(filePath, 'firstQ\r\nsecond\r\n')
+}

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandDelta.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandDelta.ts
@@ -1,4 +1,5 @@
 import * as Character from '../Character/Character.ts'
+import * as GetLineLength from '../GetLineLength/GetLineLength.ts'
 import * as TextSegmenter from '../TextSegmenter/TextSegmenter.ts'
 
 /* eslint-disable sonarjs/super-linear-regex */
@@ -50,7 +51,7 @@ export const lineCharacterStart = (line: string, columnIndex: number) => {
 }
 
 export const lineEnd = (line: string, columnIndex: number) => {
-  return line.length - columnIndex
+  return GetLineLength.getLineLength(line) - columnIndex
 }
 
 const tryRegexArray = (partialLine: string, regexArray: RegExp[]) => {

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandGetPositionLeft.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandGetPositionLeft.ts
@@ -1,3 +1,5 @@
+import * as GetLineLength from '../GetLineLength/GetLineLength.ts'
+
 // @ts-ignore
 export const editorGetPositionLeft = (rowIndex, columnIndex, lines, getDelta) => {
   if (columnIndex === 0) {
@@ -5,7 +7,7 @@ export const editorGetPositionLeft = (rowIndex, columnIndex, lines, getDelta) =>
       return { columnIndex: 0, rowIndex: 0 }
     }
     return {
-      columnIndex: lines[rowIndex - 1].length,
+      columnIndex: GetLineLength.getLineLength(lines[rowIndex - 1]),
       rowIndex: rowIndex - 1,
     }
   }
@@ -36,7 +38,7 @@ export const moveToPositionLeft = (selections, i, rowIndex, columnIndex, lines, 
       selections[i + 1] = 0
     } else {
       selections[i] = rowIndex - 1
-      selections[i + 1] = lines[rowIndex - 1].length
+      selections[i + 1] = GetLineLength.getLineLength(lines[rowIndex - 1])
     }
   } else {
     const delta = getDelta(lines[rowIndex], columnIndex)

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandGetPositionRight.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandGetPositionRight.ts
@@ -1,7 +1,9 @@
+import * as GetLineLength from '../GetLineLength/GetLineLength.ts'
+
 export const editorGetPositionRight = (position: any, lines: string, getDelta: any) => {
   const { rowIndex } = position
   const { columnIndex } = position
-  if (columnIndex >= lines[rowIndex].length) {
+  if (columnIndex >= GetLineLength.getLineLength(lines[rowIndex])) {
     if (rowIndex >= lines.length) {
       return position
     }
@@ -22,7 +24,7 @@ export const moveToPositionRight = (selections: any, i: number, rowIndex: number
     return
   }
   const line = lines[rowIndex]
-  if (columnIndex >= line.length) {
+  if (columnIndex >= GetLineLength.getLineLength(line)) {
     selections[i] = selections[i + 2] = rowIndex + 1
     selections[i + 1] = selections[i + 3] = 0
   } else {

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandSelectHorizontalRight.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandSelectHorizontalRight.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import * as Editor from '../Editor/Editor.ts'
 // @ts-ignore
+import * as GetLineLength from '../GetLineLength/GetLineLength.ts'
 import * as GetSelectionPairs from '../GetSelectionPairs/GetSelectionPairs.ts'
 
 // @ts-ignore
@@ -11,7 +12,7 @@ const getNewSelections = (selections, lines, getDelta) => {
     const line = lines[selectionEndRow]
     newSelections[i] = selectionStartRow
     newSelections[i + 1] = selectionStartColumn
-    if (selectionEndColumn >= line.length) {
+    if (selectionEndColumn >= GetLineLength.getLineLength(line)) {
       newSelections[i + 2] = selectionEndRow + 1
       newSelections[i + 3] = 0
     } else {

--- a/packages/editor-worker/src/parts/GetLineLength/GetLineLength.ts
+++ b/packages/editor-worker/src/parts/GetLineLength/GetLineLength.ts
@@ -1,0 +1,3 @@
+export const getLineLength = (line: string): number => {
+  return line.endsWith('\r') ? line.length - 1 : line.length
+}

--- a/packages/editor-worker/test/EditorCursorCharacterLeft.test.ts
+++ b/packages/editor-worker/test/EditorCursorCharacterLeft.test.ts
@@ -51,6 +51,18 @@ test('editorCursorCharacterLeft - at start of line', () => {
   })
 })
 
+test('editorCursorCharacterLeft - skips CRLF line ending', () => {
+  const editor = {
+    lineCache: [],
+    lines: ['first\r', 'second\r', ''],
+    primarySelectionIndex: 0,
+    selections: EditorSelection.fromRange(1, 0, 1, 0),
+  }
+  expect(EditorCursorLeft.cursorCharacterLeft(editor)).toMatchObject({
+    selections: EditorSelection.fromRange(0, 5, 0, 5),
+  })
+})
+
 test('editorCursorCharacterLeft - in virtual space', () => {
   const editor = {
     lineCache: [],

--- a/packages/editor-worker/test/EditorCursorCharacterRight.test.ts
+++ b/packages/editor-worker/test/EditorCursorCharacterRight.test.ts
@@ -50,6 +50,18 @@ test('editorCursorCharacterRight - at end of multiple lines', () => {
   })
 })
 
+test('editorCursorCharacterRight - skips CRLF line ending', () => {
+  const editor = {
+    lineCache: [],
+    lines: ['first\r', 'second\r', ''],
+    primarySelectionIndex: 0,
+    selections: EditorSelection.fromRange(0, 5, 0, 5),
+  }
+  expect(EditorCursorCharacterRight.cursorCharacterRight(editor)).toMatchObject({
+    selections: EditorSelection.fromRange(1, 0, 1, 0),
+  })
+})
+
 test('editorCursorCharacterRight - emoji - 👮🏽‍♀️', () => {
   const editor = {
     lineCache: [],

--- a/packages/editor-worker/test/EditorCursorEnd.test.ts
+++ b/packages/editor-worker/test/EditorCursorEnd.test.ts
@@ -28,3 +28,15 @@ test('editorCursorEnd - with selection', () => {
     selections: EditorSelection.fromRange(0, 4, 0, 4),
   })
 })
+
+test('editorCursorEnd - before CRLF line ending', () => {
+  const editor = {
+    lineCache: [],
+    lines: ['first\r', 'second\r', ''],
+    primarySelectionIndex: 0,
+    selections: EditorSelection.fromRange(0, 0, 0, 0),
+  }
+  expect(EditorCursorEnd.cursorEnd(editor)).toMatchObject({
+    selections: EditorSelection.fromRange(0, 5, 0, 5),
+  })
+})

--- a/packages/editor-worker/test/GetLineLength.test.ts
+++ b/packages/editor-worker/test/GetLineLength.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals'
+import * as GetLineLength from '../src/parts/GetLineLength/GetLineLength.ts'
+
+test('getLineLength returns regular line length', () => {
+  expect(GetLineLength.getLineLength('first')).toBe(5)
+})
+
+test('getLineLength excludes a trailing carriage return', () => {
+  expect(GetLineLength.getLineLength('first\r')).toBe(5)
+})


### PR DESCRIPTION
Fix cursor navigation so a trailing carriage return in CRLF-backed editor lines is not treated as an editable character. This prevents End/right/left navigation from placing the cursor between CR and LF and corrupting the saved line ending.

Adds focused cursor unit coverage and an enabled end-to-end regression that edits and saves a CRLF file.