### PR TITLE
fix: register add cursor shortcuts

### DIFF
--- a/packages/e2e/src/editor.multi-cursor-add-below-shortcut.ts
+++ b/packages/e2e/src/editor.multi-cursor-add-below-shortcut.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-multi-cursor-add-below-shortcut'
+
+export const test: Test = async ({ Editor, FileSystem, KeyBoard, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, `alpha\nbeta\ngamma`)
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file1.txt`)
+  await Editor.setCursor(0, 3)
+
+  await KeyBoard.press('Control+Alt+ArrowDown')
+  await Editor.type('X')
+
+  await Editor.shouldHaveText(`alpXha\nbetXa\ngamma`)
+}

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -425,12 +425,12 @@ export const getKeyBindings = () => {
     },
     {
       command: 'Editor.addCursorAbove',
-      key: KeyModifier.Alt | KeyModifier.Shift | KeyCode.UpArrow,
+      key: KeyModifier.Alt | KeyModifier.CtrlCmd | KeyCode.UpArrow,
       when: WhenExpression.FocusEditorText,
     },
     {
       command: 'Editor.addCursorBelow',
-      key: KeyModifier.Alt | KeyModifier.Shift | KeyCode.DownArrow,
+      key: KeyModifier.Alt | KeyModifier.CtrlCmd | KeyCode.DownArrow,
       when: WhenExpression.FocusEditorText,
     },
     {

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { KeyCode } from '@lvce-editor/constants'
+import { KeyCode, KeyModifier } from '@lvce-editor/constants'
 import * as GetKeyBindings from '../src/parts/GetKeyBindings/GetKeyBindings.ts'
 import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.ts'
 
@@ -8,6 +8,22 @@ test('Escape closes the focused color picker', () => {
     command: 'Editor.closeColorPicker',
     key: KeyCode.Escape,
     when: WhenExpression.FocusColorPicker,
+  })
+})
+
+test('Ctrl/Cmd+Alt+Up adds a cursor above', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.addCursorAbove',
+    key: KeyModifier.CtrlCmd | KeyModifier.Alt | KeyCode.UpArrow,
+    when: WhenExpression.FocusEditorText,
+  })
+})
+
+test('Ctrl/Cmd+Alt+Down adds a cursor below', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.addCursorBelow',
+    key: KeyModifier.CtrlCmd | KeyModifier.Alt | KeyCode.DownArrow,
+    when: WhenExpression.FocusEditorText,
   })
 })
 


### PR DESCRIPTION
Register Add Cursor Above/Below with the standard Ctrl/Cmd+Alt+Up/Down chords instead of the incorrect Alt+Shift bindings.

Adds keybinding-level regression coverage for both directions and an enabled Playwright test that presses Ctrl+Alt+ArrowDown and verifies typing occurs at both cursors.

Validated with focused unit tests, type-check, lint/format, build/static build, focused e2e, and worker memory measurement.