### PR TITLE
fix: restore block comment command

### DIFF
--- a/packages/e2e/src/editor.toggle-block-comment-command.ts
+++ b/packages/e2e/src/editor.toggle-block-comment-command.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-toggle-block-comment-command'
+
+export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.js`, 'const value = 1')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file.js`)
+  await Editor.setCursor(0, 6)
+
+  await Command.execute('Editor.toggleBlockComment')
+
+  await Editor.shouldHaveText('/*const value = 1*/')
+}

--- a/packages/e2e/src/editor.toggle-block-comment-shortcut.ts
+++ b/packages/e2e/src/editor.toggle-block-comment-shortcut.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-toggle-block-comment-shortcut'
+
+export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.js`, 'const value = 1')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file.js`)
+  await Editor.setCursor(0, 6)
+
+  const keyA = 29
+  const alt = 1 << 9
+  const shift = 1 << 10
+  const shiftAltA = shift | alt | keyA
+  await Command.execute('KeyBindings.handleKeyBinding', shiftAltA)
+
+  await Editor.shouldHaveText('/*const value = 1*/')
+}

--- a/packages/editor-worker/src/parts/GetBlockCommentEdits/GetBlockCommentEdits.ts
+++ b/packages/editor-worker/src/parts/GetBlockCommentEdits/GetBlockCommentEdits.ts
@@ -14,7 +14,7 @@ const createDeleteEdit = (rowIndex: number, columnIndex: number, text: string): 
       columnIndex: columnIndex + text.length,
       rowIndex,
     },
-    inserted: [],
+    inserted: [''],
     origin: EditOrigin.ToggleBlockComment,
     start: {
       columnIndex,
@@ -41,7 +41,7 @@ const getRemoveBlockCommentEdits = (
   return [createDeleteEdit(startRowIndex, startColumnIndex, blockCommentStart), createDeleteEdit(endRowIndex, endColumnIndex, blockCommentEnd)]
 }
 
-export const getBlockCommentEdits = (editor: any, blockComment: string): readonly Edit[] => {
+export const getBlockCommentEdits = (editor: any, blockComment: readonly string[]): readonly Edit[] => {
   const { selections } = editor
   const [rowIndex] = selections
   const line = TextDocument.getLine(editor, rowIndex)
@@ -99,7 +99,7 @@ export const getBlockCommentEdits = (editor: any, blockComment: string): readonl
       endColumnIndex -= whitespaceAtEnd[0].length
     }
     const change1: Edit = {
-      deleted: [],
+      deleted: [''],
       end: {
         columnIndex: startColumnIndex,
         rowIndex,
@@ -112,7 +112,7 @@ export const getBlockCommentEdits = (editor: any, blockComment: string): readonl
       },
     }
     const change2: Edit = {
-      deleted: [],
+      deleted: [''],
       end: {
         columnIndex: endColumnIndex + blockCommentStart.length,
         rowIndex,

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -384,6 +384,11 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusEditorText,
     },
     {
+      command: 'Editor.toggleBlockComment',
+      key: KeyModifier.Alt | KeyModifier.Shift | KeyCode.KeyA,
+      when: WhenExpression.FocusEditorText,
+    },
+    {
       command: 'Editor.copy',
       key: KeyModifier.CtrlCmd | KeyCode.KeyC,
       when: WhenExpression.FocusEditorText,

--- a/packages/editor-worker/test/GetBlockCommentEdits.test.ts
+++ b/packages/editor-worker/test/GetBlockCommentEdits.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@jest/globals'
+import * as GetBlockCommentEdits from '../src/parts/GetBlockCommentEdits/GetBlockCommentEdits.ts'
+import * as TextDocument from '../src/parts/TextDocument/TextDocument.ts'
+
+test('adds a block comment around the active line', () => {
+  const editor = {
+    lines: ['const value = 1'],
+    selections: new Uint32Array([0, 6, 0, 6]),
+  }
+
+  const edits = GetBlockCommentEdits.getBlockCommentEdits(editor, ['/*', '*/'])
+
+  expect(TextDocument.applyEdits(editor, edits)).toEqual(['/*const value = 1*/'])
+})
+
+test('removes a block comment around the active line', () => {
+  const editor = {
+    lines: ['/*const value = 1*/'],
+    selections: new Uint32Array([0, 8, 0, 8]),
+  }
+
+  const edits = GetBlockCommentEdits.getBlockCommentEdits(editor, ['/*', '*/'])
+
+  expect(TextDocument.applyEdits(editor, edits)).toEqual(['const value = 1'])
+})

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -27,6 +27,14 @@ test('Ctrl/Cmd+Alt+Down adds a cursor below', () => {
   })
 })
 
+test('Shift+Alt+A toggles a block comment', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.toggleBlockComment',
+    key: KeyModifier.Shift | KeyModifier.Alt | KeyCode.KeyA,
+    when: WhenExpression.FocusEditorText,
+  })
+})
+
 test('Escape closes focused editor completions', () => {
   expect(GetKeyBindings.getKeyBindings()).toContainEqual({
     command: 'Editor.closeCompletion',


### PR DESCRIPTION
## Summary
- represent block-comment insertions and deletions as valid single-line text edits
- restore the Shift+Alt+A editor keybinding
- add unit and end-to-end regressions for command and keybinding execution

## Validation
- npm run build
- npm run build:static
- npm test
- npm run type-check
- npm run lint
- focused toggle-block-comment e2e tests
- npm run measure (packages/build)