### PR TITLE
fix: restore editor vertical scrolling

### DIFF
--- a/packages/e2e/src/editor.vertical-scrolling.ts
+++ b/packages/e2e/src/editor.vertical-scrolling.ts
@@ -1,0 +1,38 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-vertical-scrolling'
+
+export const test: Test = async ({ Editor, expect, FileSystem, KeyBoard, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const content = Array.from({ length: 100 }, (_, index) => `line ${index + 1}`).join('\n')
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, content)
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file.txt`)
+
+  const editor = Locator('.EditorContent')
+  await editor.dispatchEvent('wheel', {
+    bubbles: true,
+    deltaMode: 0,
+    deltaX: 0,
+    deltaY: 600,
+  } as any)
+
+  const line31 = Locator('.EditorRow', { hasText: 'line 31' })
+  await expect(line31).toBeVisible()
+
+  await Editor.setCursor(0, 0)
+  await KeyBoard.press('PageDown')
+
+  const cursor = Locator('.EditorCursor')
+  const line26 = Locator('.EditorRow', { hasText: 'line 26' })
+  await expect(cursor).toBeVisible()
+  await expect(line26).toBeVisible()
+
+  await Editor.setCursor(0, 0)
+  for (let i = 0; i < 26; i++) {
+    await KeyBoard.press('ArrowDown')
+  }
+
+  await Editor.shouldHaveSelections(new Uint32Array([26, 0, 26, 0]))
+  await expect(cursor).toBeVisible()
+}

--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -29,6 +29,7 @@ import * as CursorCharacterRight from '../EditorCommand/EditorCommandCursorChara
 import * as CursorDown from '../EditorCommand/EditorCommandCursorDown.ts'
 import * as CursorEnd from '../EditorCommand/EditorCommandCursorEnd.ts'
 import * as CursorHome from '../EditorCommand/EditorCommandCursorHome.ts'
+import { cursorPageDown } from '../EditorCommand/EditorCommandCursorPageDown.ts'
 import * as EditorCursorSet from '../EditorCommand/EditorCommandCursorSet.ts'
 import * as CursorUp from '../EditorCommand/EditorCommandCursorUp.ts'
 import * as CursorWordLeft from '../EditorCommand/EditorCommandCursorWordLeft.ts'
@@ -212,6 +213,7 @@ export const commandMap = {
   'Editor.cursorEnd': wrapCommand(CursorEnd.cursorEnd),
   'Editor.cursorHome': wrapCommand(CursorHome.cursorHome),
   'Editor.cursorLeft': wrapCommand(CursorCharacterLeft.cursorCharacterLeft),
+  'Editor.cursorPageDown': wrapCommand(cursorPageDown),
   'Editor.cursorRight': wrapCommand(CursorCharacterRight.cursorCharacterRight),
   'Editor.cursorSet': wrapCommand(EditorCursorSet.cursorSet),
   'Editor.cursorUp': wrapCommand(CursorUp.cursorUp),

--- a/packages/editor-worker/src/parts/Editor/EditorSelection.ts
+++ b/packages/editor-worker/src/parts/Editor/EditorSelection.ts
@@ -1,5 +1,7 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as Clamp from '../Clamp/Clamp.ts'
 import * as EditorSelection from '../EditorSelection/EditorSelection.ts'
+import * as ScrollBarFunctions from '../ScrollBarFunctions/ScrollBarFunctions.ts'
 
 const getSelectionFromChange = (change: any) => {
   const { inserted, start } = change
@@ -28,13 +30,34 @@ const getSelectionFromChange = (change: any) => {
 
 export const setSelections = (editor: any, selections: any) => {
   Assert.object(editor)
-  // Assert.uint32array(selections)
-  return {
+  const newEditor = {
     ...editor,
     selections,
   }
-  // editor.selections = selections
-  // GlobalEventBus.emitEvent('editor.selectionChange', editor, selections)
+  const { maxLineY, minLineY, numberOfVisibleLines } = editor
+  if (maxLineY === undefined || minLineY === undefined || numberOfVisibleLines <= 0) {
+    return newEditor
+  }
+  const rowIndex = selections[editor.primarySelectionIndex || 0]
+  if (rowIndex === undefined) {
+    return newEditor
+  }
+  if (rowIndex >= minLineY && rowIndex < maxLineY) {
+    return newEditor
+  }
+  const { finalDeltaY, height, itemHeight, lines, scrollBarHeight } = editor
+  const desiredMinLineY = rowIndex < minLineY ? rowIndex : rowIndex - numberOfVisibleLines + 1
+  const deltaY = Clamp.clamp(desiredMinLineY * itemHeight, 0, finalDeltaY)
+  const newMinLineY = Math.floor(deltaY / itemHeight)
+  const newMaxLineY = Math.min(newMinLineY + numberOfVisibleLines, lines.length)
+  const scrollBarY = ScrollBarFunctions.getScrollBarY(deltaY, finalDeltaY, height, scrollBarHeight)
+  return {
+    ...newEditor,
+    deltaY,
+    maxLineY: newMaxLineY,
+    minLineY: newMinLineY,
+    scrollBarY,
+  }
 }
 
 // TODO maybe only accept sorted selection edits in the first place

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorPageDown.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorPageDown.ts
@@ -1,0 +1,16 @@
+import * as Editor from '../Editor/Editor.ts'
+import * as EditorSelection from '../EditorSelection/EditorSelection.ts'
+
+export const cursorPageDown = (editor: any) => {
+  const { deltaY, itemHeight, lines, numberOfVisibleLines, selections } = editor
+  const pageSize = Math.max(numberOfVisibleLines, 1)
+  const lastRowIndex = lines.length - 1
+  const newSelections = EditorSelection.map(
+    selections,
+    (result: any, index: number, _startRow: number, _startColumn: number, endRow: number, endColumn: number) => {
+      EditorSelection.moveRangeToPosition(result, index, Math.min(endRow + pageSize, lastRowIndex), endColumn)
+    },
+  )
+  const newEditor = Editor.scheduleSelections(editor, newSelections)
+  return Editor.setDeltaYFixedValue(newEditor, deltaY + pageSize * itemHeight)
+}

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandSetSelections.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandSetSelections.ts
@@ -1,28 +1,5 @@
+import * as Editor from '../Editor/Editor.ts'
+
 export const setSelections = (editor: any, selections: any) => {
-  const { maxLineY, minLineY, rowHeight } = editor
-  const startRowIndex = selections[0]
-  if (startRowIndex < minLineY) {
-    const deltaY = startRowIndex * rowHeight
-    return {
-      ...editor,
-      deltaY,
-      maxLineY: startRowIndex + 1,
-      minLineY: startRowIndex,
-      selections,
-    }
-  }
-  if (startRowIndex > maxLineY) {
-    const deltaY = startRowIndex * rowHeight
-    return {
-      ...editor,
-      deltaY,
-      maxLineY: startRowIndex + 1,
-      minLineY: startRowIndex,
-      selections,
-    }
-  }
-  return {
-    ...editor,
-    selections,
-  }
+  return Editor.scheduleSelections(editor, selections)
 }

--- a/packages/editor-worker/src/parts/GetEditorContentVirtualDom/GetEditorContentVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorContentVirtualDom/GetEditorContentVirtualDom.ts
@@ -37,6 +37,7 @@ export const getEditorContentVirtualDom = ({
       className: 'EditorContent',
       onKeyUp: DomEventListenerFunctions.HandleKeyUp,
       onMouseMove: DomEventListenerFunctions.HandleMouseMove,
+      onWheel: DomEventListenerFunctions.HandleWheel,
       type: VirtualDomElements.Div,
     },
     ...GetEditorInputVirtualDom.getEditorInputVirtualDom(),

--- a/packages/editor-worker/src/parts/GetEditorRowsLayerVirtualDom/GetEditorRowsLayerVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorRowsLayerVirtualDom/GetEditorRowsLayerVirtualDom.ts
@@ -16,7 +16,6 @@ export const getEditorRowsVirtualDom = (
       className: 'EditorRows',
       onMouseDown: DomEventListenerFunctions.HandleMouseDown,
       onPointerDown: DomEventListenerFunctions.HandlePointerDown,
-      onWheel: DomEventListenerFunctions.HandleWheel,
       type: VirtualDomElements.Div,
     },
     ...rowsDom,

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -319,6 +319,11 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusEditorText,
     },
     {
+      command: 'Editor.cursorPageDown',
+      key: KeyCode.PageDown,
+      when: WhenExpression.FocusEditorText,
+    },
+    {
       command: 'Editor.deleteLeft',
       key: KeyCode.Backspace,
       when: WhenExpression.FocusEditorText,

--- a/packages/editor-worker/test/EditorCommandSetSelection.test.ts
+++ b/packages/editor-worker/test/EditorCommandSetSelection.test.ts
@@ -14,10 +14,16 @@ test('setSelections', () => {
 
 test('setSelections - scroll down', () => {
   const editor = {
+    deltaY: 0,
+    finalDeltaY: 40,
+    height: 20,
+    itemHeight: 20,
     lineCache: [],
     lines: ['line 1', 'line 2', 'line 3'],
     maxLineY: 1,
     minLineY: 0,
+    numberOfVisibleLines: 1,
+    scrollBarHeight: 10,
     selections: new Uint32Array([0, 0, 0, 0]),
   }
   expect(EditorCommandSetSelections.setSelections(editor, new Uint32Array([2, 0, 2, 0]))).toMatchObject({
@@ -29,10 +35,16 @@ test('setSelections - scroll down', () => {
 
 test('setSelections - scroll up', () => {
   const editor = {
+    deltaY: 40,
+    finalDeltaY: 40,
+    height: 20,
+    itemHeight: 20,
     lineCache: [],
     lines: ['line 1', 'line 2', 'line 3'],
     maxLineY: 3,
     minLineY: 2,
+    numberOfVisibleLines: 1,
+    scrollBarHeight: 10,
     selections: new Uint32Array([2, 0, 0, 2]),
   }
   expect(EditorCommandSetSelections.setSelections(editor, new Uint32Array([0, 0, 0, 0]))).toMatchObject({

--- a/packages/editor-worker/test/EditorSelectionSetSelections.test.ts
+++ b/packages/editor-worker/test/EditorSelectionSetSelections.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@jest/globals'
+import { setSelections } from '../src/parts/Editor/EditorSelection.ts'
+
+const createEditor = () => ({
+  deltaY: 0,
+  finalDeltaY: 60,
+  height: 40,
+  itemHeight: 20,
+  lines: ['a', 'b', 'c', 'd', 'e'],
+  maxLineY: 2,
+  minLineY: 0,
+  numberOfVisibleLines: 2,
+  primarySelectionIndex: 0,
+  scrollBarHeight: 20,
+})
+
+test('reveals a selection below the viewport', () => {
+  const selections = new Uint32Array([2, 0, 2, 0])
+  expect(setSelections(createEditor(), selections)).toMatchObject({
+    deltaY: 20,
+    maxLineY: 3,
+    minLineY: 1,
+    selections,
+  })
+})
+
+test('reveals a selection above the viewport', () => {
+  const selections = new Uint32Array([0, 0, 0, 0])
+  expect(
+    setSelections(
+      {
+        ...createEditor(),
+        deltaY: 40,
+        maxLineY: 4,
+        minLineY: 2,
+      },
+      selections,
+    ),
+  ).toMatchObject({
+    deltaY: 0,
+    maxLineY: 2,
+    minLineY: 0,
+    selections,
+  })
+})

--- a/packages/editor-worker/test/GetEditorContentVirtualDom.test.ts
+++ b/packages/editor-worker/test/GetEditorContentVirtualDom.test.ts
@@ -22,6 +22,7 @@ test('getEditorContentVirtualDom', () => {
     className: 'EditorContent',
     onKeyUp: DomEventListenerFunctions.HandleKeyUp,
     onMouseMove: DomEventListenerFunctions.HandleMouseMove,
+    onWheel: DomEventListenerFunctions.HandleWheel,
     type: VirtualDomElements.Div,
   })
 

--- a/packages/editor-worker/test/GetEditorRowsLayerVirtualDom.test.ts
+++ b/packages/editor-worker/test/GetEditorRowsLayerVirtualDom.test.ts
@@ -18,7 +18,6 @@ test('getEditorRowsVirtualDom', () => {
     className: 'EditorRows',
     onMouseDown: DomEventListenerFunctions.HandleMouseDown,
     onPointerDown: DomEventListenerFunctions.HandlePointerDown,
-    onWheel: DomEventListenerFunctions.HandleWheel,
     type: VirtualDomElements.Div,
   })
   expect(dom.slice(1)).toEqual([

--- a/packages/editor-worker/test/GetEditorVirtualDom.test.ts
+++ b/packages/editor-worker/test/GetEditorVirtualDom.test.ts
@@ -56,6 +56,7 @@ test('getEditorVirtualDom', () => {
       className: 'EditorContent',
       onKeyUp: DomEventListenerFunctions.HandleKeyUp,
       onMouseMove: DomEventListenerFunctions.HandleMouseMove,
+      onWheel: DomEventListenerFunctions.HandleWheel,
       type: VirtualDomElements.Div,
     },
     {
@@ -109,7 +110,6 @@ test('getEditorVirtualDom', () => {
       className: 'EditorRows',
       onMouseDown: DomEventListenerFunctions.HandleMouseDown,
       onPointerDown: DomEventListenerFunctions.HandlePointerDown,
-      onWheel: DomEventListenerFunctions.HandleWheel,
       type: VirtualDomElements.Div,
     },
     {

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -43,6 +43,14 @@ test('F9 toggles a breakpoint', () => {
   })
 })
 
+test('PageDown advances the editor viewport', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.cursorPageDown',
+    key: KeyCode.PageDown,
+    when: WhenExpression.FocusEditorText,
+  })
+})
+
 test('Escape closes focused editor completions', () => {
   expect(GetKeyBindings.getKeyBindings()).toContainEqual({
     command: 'Editor.closeCompletion',


### PR DESCRIPTION
## Summary
- listen for wheel input across the complete editor content area
- keep the viewport synchronized with selection and cursor movement
- add a Page Down editor command and keybinding
- add an end-to-end regression covering wheel, Page Down, and repeated Arrow Down scrolling

## Validation
- npm run type-check
- npm run lint
- npm run build
- npm test
- npm run measure (398,788 used; 773,712 embedder heap)
- editor.vertical-scrolling e2e
- editor.cursor-down* e2e