### PR TITLE
fix: paste at editor context menu location

### DIFF
--- a/packages/e2e/src/editor.context-menu-paste-at-click-location.ts
+++ b/packages/e2e/src/editor.context-menu-paste-at-click-location.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.context-menu-paste-at-click-location'
+
+export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'first line\nsecond line\nfinal line')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file1.txt`)
+  await Editor.setCursor(1, 7)
+
+  await Command.execute('Editor.handleMouseDown', 2, false, false, 0, 100, 1)
+  await Command.execute('Editor.pasteText', 'CTX')
+
+  await Editor.shouldHaveText('first line\nsecond line\nCTXfinal line')
+}

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandHandleMouseDown.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandHandleMouseDown.ts
@@ -1,11 +1,40 @@
 import type { EditorState } from '../State/State.ts'
 import * as ClickDetailType from '../ClickDetailType/ClickDetailType.ts'
 import * as GetModifier from '../GetModifier/GetModifier.ts'
+import * as GetSelectionPairs from '../GetSelectionPairs/GetSelectionPairs.ts'
+import { handleClickAtPosition } from './EditorCommandHandleClickAtPosition.ts'
 import * as EditorHandleDoubleClick from './EditorCommandHandleDoubleClick.ts'
 import * as EditorHandleSingleClick from './EditorCommandHandleSingleClick.ts'
 import * as EditorHandleTripleClick from './EditorCommandHandleTripleClick.ts'
+import * as EditorPosition from './EditorCommandPosition.ts'
 
 const PrimaryButton = 0
+const SecondaryButton = 2
+
+const isPositionBeforeOrEqual = (rowIndex: number, columnIndex: number, otherRowIndex: number, otherColumnIndex: number): boolean => {
+  return rowIndex < otherRowIndex || (rowIndex === otherRowIndex && columnIndex <= otherColumnIndex)
+}
+
+const isPositionInSelection = (selections: Uint32Array, rowIndex: number, columnIndex: number): boolean => {
+  for (let i = 0; i < selections.length; i += 4) {
+    const [startRowIndex, startColumnIndex, endRowIndex, endColumnIndex] = GetSelectionPairs.getSelectionPairs(selections, i)
+    if (
+      isPositionBeforeOrEqual(startRowIndex, startColumnIndex, rowIndex, columnIndex) &&
+      isPositionBeforeOrEqual(rowIndex, columnIndex, endRowIndex, endColumnIndex)
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+const handleSecondaryMouseDown = async (state: EditorState, x: number, y: number): Promise<EditorState> => {
+  const position = await EditorPosition.at(state, x, y)
+  if (isPositionInSelection(state.selections, position.rowIndex, position.columnIndex)) {
+    return state
+  }
+  return handleClickAtPosition(state, 0, position.rowIndex, position.columnIndex)
+}
 
 export const handleMouseDown = async (
   state: EditorState,
@@ -16,6 +45,9 @@ export const handleMouseDown = async (
   y: number,
   detail: any,
 ): Promise<EditorState> => {
+  if (button === SecondaryButton) {
+    return handleSecondaryMouseDown(state, x, y)
+  }
   if (button !== PrimaryButton) {
     return state
   }

--- a/packages/editor-worker/test/EditorCommandHandleMouseDown.test.ts
+++ b/packages/editor-worker/test/EditorCommandHandleMouseDown.test.ts
@@ -46,13 +46,39 @@ test('handleMouseDown - single click sets collapsed selection and starts selecti
   })
 })
 
-test('handleMouseDown - right click keeps selection unchanged', async () => {
+test('handleMouseDown - right click inside selection keeps selection unchanged', async () => {
+  const editor = {
+    ...createEditor(),
+    selections: new Uint32Array([0, 0, 0, 5]),
+  }
+
+  const result = await EditorCommandHandleMouseDown.handleMouseDown(editor as any, 2, false, false, 24, 0, 1)
+
+  expect(result).toBe(editor)
+})
+
+test('handleMouseDown - right click outside selection moves cursor', async () => {
   const editor = {
     ...createEditor(),
     selections: new Uint32Array([0, 0, 0, 5]),
   }
 
   const result = await EditorCommandHandleMouseDown.handleMouseDown(editor as any, 2, false, false, 80, 0, 1)
+
+  expect(result).toMatchObject({
+    focused: true,
+    isSelecting: false,
+    selections: new Uint32Array([0, 10, 0, 10]),
+  })
+})
+
+test('handleMouseDown - right click inside reversed selection keeps selection unchanged', async () => {
+  const editor = {
+    ...createEditor(),
+    selections: new Uint32Array([0, 5, 0, 0]),
+  }
+
+  const result = await EditorCommandHandleMouseDown.handleMouseDown(editor as any, 2, false, false, 24, 0, 1)
 
   expect(result).toBe(editor)
 })


### PR DESCRIPTION
## Summary
- move the editor caret to a secondary-click position when it is outside the current selections
- preserve existing selections when secondary-clicking within selected text, including reversed selections
- add an E2E regression proving Paste uses the secondary-clicked line

## Validation
- `npm test`
- `npm run type-check`
- `npm run lint`
- focused `EditorCommandHandleMouseDown` unit suite
- `editor.context-menu-paste-at-click-location` E2E
- `editor.context-menu-preserve-selection` E2E