### PR TITLE
fix: add document boundary shortcuts

### DIFF
--- a/packages/e2e/src/editor.document-boundary-shortcuts.ts
+++ b/packages/e2e/src/editor.document-boundary-shortcuts.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.document-boundary-shortcuts'
+
+export const test: Test = async ({ Editor, FileSystem, KeyBoard, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'first\nmiddle\nlast')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file1.txt`)
+  await Editor.setCursor(0, 3)
+
+  await KeyBoard.press('Control+End')
+  await Editor.type('X')
+  await Editor.shouldHaveText('first\nmiddle\nlastX')
+
+  await KeyBoard.press('Control+Home')
+  await Editor.type('Y')
+  await Editor.shouldHaveText('Yfirst\nmiddle\nlastX')
+}

--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -26,6 +26,8 @@ import * as CopyLineDown from '../EditorCommand/EditorCommandCopyLineDown.ts'
 import * as CopyLineUp from '../EditorCommand/EditorCommandCopyLineUp.ts'
 import * as CursorCharacterLeft from '../EditorCommand/EditorCommandCursorCharacterLeft.ts'
 import * as CursorCharacterRight from '../EditorCommand/EditorCommandCursorCharacterRight.ts'
+import * as CursorDocumentEnd from '../EditorCommand/EditorCommandCursorDocumentEnd.ts'
+import * as CursorDocumentStart from '../EditorCommand/EditorCommandCursorDocumentStart.ts'
 import * as CursorDown from '../EditorCommand/EditorCommandCursorDown.ts'
 import * as CursorEnd from '../EditorCommand/EditorCommandCursorEnd.ts'
 import * as CursorHome from '../EditorCommand/EditorCommandCursorHome.ts'
@@ -212,6 +214,8 @@ export const commandMap = {
   'Editor.create2': createEditor2,
   'Editor.cursorCharacterLeft': wrapCommand(CursorCharacterLeft.cursorCharacterLeft),
   'Editor.cursorCharacterRight': wrapCommand(CursorCharacterRight.cursorCharacterRight),
+  'Editor.cursorDocumentEnd': wrapCommand(CursorDocumentEnd.cursorDocumentEnd),
+  'Editor.cursorDocumentStart': wrapCommand(CursorDocumentStart.cursorDocumentStart),
   'Editor.cursorDown': wrapCommand(CursorDown.cursorDown),
   'Editor.cursorEnd': wrapCommand(CursorEnd.cursorEnd),
   'Editor.cursorHome': wrapCommand(CursorHome.cursorHome),

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorDocumentEnd.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorDocumentEnd.ts
@@ -1,0 +1,15 @@
+import * as Editor from '../Editor/Editor.ts'
+
+export const cursorDocumentEnd = (editor: any) => {
+  const { lines, selections } = editor
+  const rowIndex = lines.length - 1
+  const columnIndex = lines[rowIndex].length
+  const newSelections = new Uint32Array(selections.length)
+  for (let i = 0; i < newSelections.length; i += 4) {
+    newSelections[i] = rowIndex
+    newSelections[i + 1] = columnIndex
+    newSelections[i + 2] = rowIndex
+    newSelections[i + 3] = columnIndex
+  }
+  return Editor.scheduleSelections(editor, newSelections)
+}

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorDocumentStart.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorDocumentStart.ts
@@ -1,0 +1,6 @@
+import * as Editor from '../Editor/Editor.ts'
+
+export const cursorDocumentStart = (editor: any) => {
+  const newSelections = new Uint32Array(editor.selections.length)
+  return Editor.scheduleSelections(editor, newSelections)
+}

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -174,6 +174,16 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusEditorText,
     },
     {
+      command: 'Editor.cursorDocumentEnd',
+      key: KeyModifier.CtrlCmd | KeyCode.End,
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      command: 'Editor.cursorDocumentStart',
+      key: KeyModifier.CtrlCmd | KeyCode.Home,
+      when: WhenExpression.FocusEditorText,
+    },
+    {
       command: 'Editor.deleteWordPartLeft',
       key: KeyModifier.Alt | KeyCode.Backspace,
       when: WhenExpression.FocusEditorText,

--- a/packages/editor-worker/test/EditorCursorDocumentBoundary.test.ts
+++ b/packages/editor-worker/test/EditorCursorDocumentBoundary.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@jest/globals'
+import * as CursorDocumentEnd from '../src/parts/EditorCommand/EditorCommandCursorDocumentEnd.ts'
+import * as CursorDocumentStart from '../src/parts/EditorCommand/EditorCommandCursorDocumentStart.ts'
+import * as EditorSelection from '../src/parts/EditorSelection/EditorSelection.ts'
+
+const createEditor = (selections: Uint32Array) => ({
+  lineCache: [],
+  lines: ['first', 'middle', 'last'],
+  primarySelectionIndex: 0,
+  selections,
+})
+
+test('cursorDocumentStart moves the cursor to the start of the document', () => {
+  const editor = createEditor(EditorSelection.fromRange(1, 3, 1, 3))
+
+  expect(CursorDocumentStart.cursorDocumentStart(editor)).toMatchObject({
+    selections: EditorSelection.fromRange(0, 0, 0, 0),
+  })
+})
+
+test('cursorDocumentEnd moves the cursor to the end of the document', () => {
+  const editor = createEditor(EditorSelection.fromRange(0, 3, 0, 3))
+
+  expect(CursorDocumentEnd.cursorDocumentEnd(editor)).toMatchObject({
+    selections: EditorSelection.fromRange(2, 4, 2, 4),
+  })
+})
+
+test('document boundary movement collapses selections and multiple cursors', () => {
+  const editor = createEditor(new Uint32Array([0, 1, 1, 4, 2, 2, 2, 2]))
+
+  expect(CursorDocumentStart.cursorDocumentStart(editor)).toMatchObject({
+    selections: new Uint32Array([0, 0, 0, 0, 0, 0, 0, 0]),
+  })
+  expect(CursorDocumentEnd.cursorDocumentEnd(editor)).toMatchObject({
+    selections: new Uint32Array([2, 4, 2, 4, 2, 4, 2, 4]),
+  })
+})

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -35,6 +35,23 @@ test('Ctrl/Cmd+Shift+K deletes the active line', () => {
   })
 })
 
+test('Ctrl/Cmd+Home and Ctrl/Cmd+End move to document boundaries', () => {
+  expect(GetKeyBindings.getKeyBindings()).toEqual(
+    expect.arrayContaining([
+      {
+        command: 'Editor.cursorDocumentStart',
+        key: KeyModifier.CtrlCmd | KeyCode.Home,
+        when: WhenExpression.FocusEditorText,
+      },
+      {
+        command: 'Editor.cursorDocumentEnd',
+        key: KeyModifier.CtrlCmd | KeyCode.End,
+        when: WhenExpression.FocusEditorText,
+      },
+    ]),
+  )
+})
+
 test('Shift+Alt+A toggles a block comment', () => {
   expect(GetKeyBindings.getKeyBindings()).toContainEqual({
     command: 'Editor.toggleBlockComment',


### PR DESCRIPTION
## Summary
- add document-start and document-end editor cursor commands
- bind Ctrl/Cmd+Home and Ctrl/Cmd+End while editor text is focused
- add unit coverage for cursor/selection behavior and an end-to-end shortcut regression

## Validation
- `npm test`
- `npm run type-check`
- `npm run lint`
- `npm run build && npm run build:static`
- `npm run e2e:headless -- --filter=editor.document-boundary-shortcuts`