### PR TITLE
test: cover double-click word selection

### DIFF
--- a/packages/e2e/src/editor.double-click-selects-word.ts
+++ b/packages/e2e/src/editor.double-click-selects-word.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.double-click-selects-word'
+
+export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'second line with words')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file1.txt`)
+
+  await Command.execute('Editor.handleMouseDown', 0, false, false, 64, 60, 2)
+
+  await Editor.shouldHaveSelections(new Uint32Array([0, 7, 0, 11]))
+}


### PR DESCRIPTION
## Summary
- add an end-to-end regression for double-click word selection
- route the gesture through the editor mouse-down command and assert only the target word is selected

The underlying behavior and focused unit regression are already present on current `main`; this adds browser-facing integration coverage for the older manual report.

## Validation
- `npm run type-check`
- `npm run lint`
- focused `EditorCommandHandleMouseDown.test.ts`
- `npm run build && npm run build:static`
- `npm run e2e:headless -- --filter=editor.double-click-selects-word`