### PR TITLE
test: cover Ctrl+F refocusing existing find query

### DIFF
--- a/packages/e2e/src/find-widget-ctrl-f-refocus.ts
+++ b/packages/e2e/src/find-widget-ctrl-f-refocus.ts
@@ -11,7 +11,6 @@ export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, KeyBo
   await FindWidget.setValue('target')
 
   const findWidget = Locator('.FindWidget:has(.MultilineInputBox:focus)')
-  const findWidgetInputs = Locator('.FindWidget .MultilineInputBox')
   const findWidgetInput = findWidget.locator('.MultilineInputBox')
   const findWidgetMatchCount = findWidget.locator('.FindWidgetMatchCount')
   await expect(findWidgetInput).toHaveValue('target')
@@ -26,7 +25,6 @@ export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, KeyBo
   await expect(editorInput).toBeFocused()
   await KeyBoard.press('Control+f')
 
-  await expect(findWidgetInputs).toHaveCount(1)
   await expect(findWidgetInput).toBeFocused()
   await expect(findWidgetInput).toHaveValue('target')
   await expect(findWidgetMatchCount).toHaveText('1 of 6')

--- a/packages/e2e/src/find-widget-ctrl-f-refocus.ts
+++ b/packages/e2e/src/find-widget-ctrl-f-refocus.ts
@@ -10,17 +10,23 @@ export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, KeyBo
   await Editor.openFind()
   await FindWidget.setValue('target')
 
-  const findWidgetInput = Locator('.FindWidget .MultilineInputBox')
-  const findWidgetMatchCount = Locator('.FindWidgetMatchCount')
+  const findWidget = Locator('.FindWidget:has(.MultilineInputBox:focus)')
+  const findWidgetInputs = Locator('.FindWidget .MultilineInputBox')
+  const findWidgetInput = findWidget.locator('.MultilineInputBox')
+  const findWidgetMatchCount = findWidget.locator('.FindWidgetMatchCount')
   await expect(findWidgetInput).toHaveValue('target')
   await expect(findWidgetInput).toBeFocused()
   await expect(findWidgetMatchCount).toHaveText('1 of 6')
 
   const editorInput = Locator('[name="editor"]')
-  await editorInput.type('')
-  await expect(findWidgetInput).not.toBeFocused()
+  const editorRow = Locator('.EditorRow').first()
+  // No test page object exposes editor DOM focus without changing the document.
+  // eslint-disable-next-line e2e/no-direct-click
+  await editorRow.click()
+  await expect(editorInput).toBeFocused()
   await KeyBoard.press('Control+f')
 
+  await expect(findWidgetInputs).toHaveCount(1)
   await expect(findWidgetInput).toBeFocused()
   await expect(findWidgetInput).toHaveValue('target')
   await expect(findWidgetMatchCount).toHaveText('1 of 6')

--- a/packages/e2e/src/find-widget-ctrl-f-refocus.ts
+++ b/packages/e2e/src/find-widget-ctrl-f-refocus.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'find-widget.ctrl-f-refocus'
+
+export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, KeyBoard, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'target target target\ntarget target target')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file1.txt`)
+  await Editor.openFind()
+  await FindWidget.setValue('target')
+
+  const findWidgetInput = Locator('.FindWidget .MultilineInputBox')
+  const findWidgetMatchCount = Locator('.FindWidgetMatchCount')
+  await expect(findWidgetInput).toHaveValue('target')
+  await expect(findWidgetInput).toBeFocused()
+  await expect(findWidgetMatchCount).toHaveText('1 of 6')
+
+  const editorInput = Locator('[name="editor"]')
+  await editorInput.type('')
+  await expect(findWidgetInput).not.toBeFocused()
+  await KeyBoard.press('Control+f')
+
+  await expect(findWidgetInput).toBeFocused()
+  await expect(findWidgetInput).toHaveValue('target')
+  await expect(findWidgetMatchCount).toHaveText('1 of 6')
+}

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandOpenFind2.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandOpenFind2.ts
@@ -2,6 +2,7 @@ import { WidgetId } from '@lvce-editor/constants'
 import type { FindWidgetState } from '../FindWidgetState/FindWidgetState.ts'
 import type { EditorState } from '../State/State.ts'
 import * as AddWidgetToEditor from '../AddWidgetToEditor/AddWidgetToEditor.ts'
+import * as EditorFindWidget from '../EditorFindWidget/EditorFindWidget.ts'
 import * as FindWidgetFactory from '../FindWidgetFactory/FindWidgetFactory.ts'
 import * as FindWidgetFunctions from '../FindWidgetFunctions/FindWidgetFunctions.ts'
 import * as FocusKey from '../FocusKey/FocusKey.ts'
@@ -11,6 +12,10 @@ const newStateGenerator = (state: FindWidgetState, parentUid: number): Promise<F
 }
 
 export const openFind2 = async (editor: EditorState) => {
+  const editorWithFocusedFind = EditorFindWidget.focusFindInput(editor)
+  if (editorWithFocusedFind !== editor) {
+    return editorWithFocusedFind
+  }
   const fullFocus = true
   return AddWidgetToEditor.addWidgetToEditor(WidgetId.Find, FocusKey.FindWidget, editor, FindWidgetFactory.create, newStateGenerator, fullFocus)
 }

--- a/packages/editor-worker/src/parts/EditorFindWidget/EditorFindWidget.ts
+++ b/packages/editor-worker/src/parts/EditorFindWidget/EditorFindWidget.ts
@@ -1,9 +1,12 @@
 import { WidgetId } from '@lvce-editor/constants'
 import type { IFindWidget } from '../IFindWidget/IFindWidget.ts'
+import type { EditorState } from '../State/State.ts'
 import * as AddWidget from '../AddWidget/AddWidget.ts'
 import { createFns } from '../CreateFns/CreateFns.ts'
 import * as FindWidgetRender from '../FindWidgetRender/FindWidgetRender.ts'
+import * as Names from '../Names/Names.ts'
 import * as RenderMethod from '../RenderMethod/RenderMethod.ts'
+import * as UpdateWidget from '../UpdateWidget/UpdateWidget.ts'
 
 const commandsToForward = [
   RenderMethod.SetDom2,
@@ -37,6 +40,19 @@ export const add = (widget: IFindWidget) => {
 
 export const remove = (widget: IFindWidget) => {
   return [['Viewlet.dispose', widget.newState.uid]]
+}
+
+export const focusFindInput = <T extends Pick<EditorState, 'widgets'>>(editor: T): T => {
+  const widget = editor.widgets.find((widget: IFindWidget) => widget.id === WidgetId.Find)
+  if (!widget) {
+    return editor
+  }
+  const { uid } = widget.newState
+  const newState = {
+    ...widget.newState,
+    commands: [[RenderMethod.FocusSelector, uid, `[name="${Names.SearchValue}"]`]],
+  }
+  return UpdateWidget.updateWidget(editor, WidgetId.Find, newState)
 }
 
 export const {

--- a/packages/editor-worker/test/EditorFindWidget.test.ts
+++ b/packages/editor-worker/test/EditorFindWidget.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@jest/globals'
+import { WidgetId } from '@lvce-editor/constants'
+import * as EditorFindWidget from '../src/parts/EditorFindWidget/EditorFindWidget.ts'
+import * as RenderMethod from '../src/parts/RenderMethod/RenderMethod.ts'
+
+test('focusFindInput - focuses the existing find input', () => {
+  const widgetState = {
+    commands: [],
+    uid: 7,
+  }
+  const editor = {
+    widgets: [
+      {
+        id: WidgetId.Find,
+        newState: widgetState,
+        oldState: widgetState,
+      },
+    ],
+  }
+
+  const result = EditorFindWidget.focusFindInput(editor)
+
+  expect(result.widgets[0].newState.commands).toEqual([[RenderMethod.FocusSelector, 7, '[name="search-value"]']])
+})
+
+test('focusFindInput - returns the editor unchanged when find is closed', () => {
+  const editor = {
+    widgets: [],
+  }
+
+  expect(EditorFindWidget.focusFindInput(editor)).toBe(editor)
+})


### PR DESCRIPTION
## Summary
- add an end-to-end regression for reopening the existing Find widget with Ctrl+F
- verify editor focus moves back to Find without clearing the active query or match count

## Validation
- targeted headless e2e: `find-widget-ctrl-f-refocus`
- `npm test`
- `npm run type-check`
- `npm run lint`