### PR TITLE
fix: navigate find matches with shift enter

### DIFF
--- a/packages/e2e/src/find-widget-keyboard-navigation.ts
+++ b/packages/e2e/src/find-widget-keyboard-navigation.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'find-widget-keyboard-navigation'
 
-export const test: Test = async ({ Editor, expect, FileSystem, KeyBoard, Locator, Main, Workspace }) => {
+export const test: Test = async ({ Command, Editor, expect, FileSystem, KeyBoard, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(
@@ -31,6 +31,21 @@ content 3`,
   // assert - should move to next match without inserting a line break
   await expect(findWidgetInput).toBeFocused()
   await expect(findWidgetMatchCount).toHaveText('2 of 3')
+  await Editor.shouldHaveSelections(new Uint32Array([1, 0, 1, 7]))
+
+  // act - go to the previous match without inserting a line break
+  await Command.execute('TestFrameWork.performKeyBoardAction', 'press', {
+    bubbles: true,
+    cancelable: true,
+    key: 'Enter',
+    shiftKey: true,
+  })
+
+  // assert - query and document stay unchanged
+  await expect(findWidgetInput).toBeFocused()
+  await expect(findWidgetInput).toHaveValue('content')
+  await expect(findWidgetMatchCount).toHaveText('1 of 3')
+  await Editor.shouldHaveSelections(new Uint32Array([0, 0, 0, 7]))
   await Editor.shouldHaveText(`content 1
 content 2
 content 3`)

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -44,6 +44,11 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusFindWidget,
     },
     {
+      command: 'FindWidget.focusPrevious',
+      key: KeyModifier.Shift | KeyCode.Enter,
+      when: WhenExpression.FocusFindWidget,
+    },
+    {
       command: 'FindWidget.preventDefaultBrowserFind',
       key: KeyModifier.CtrlCmd | KeyCode.KeyF,
       when: WhenExpression.FocusFindWidget,

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -11,6 +11,14 @@ test('Escape closes the focused color picker', () => {
   })
 })
 
+test('Shift+Enter focuses the previous find match', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'FindWidget.focusPrevious',
+    key: KeyModifier.Shift | KeyCode.Enter,
+    when: WhenExpression.FocusFindWidget,
+  })
+})
+
 test('Ctrl/Cmd+Alt+Up adds a cursor above', () => {
   expect(GetKeyBindings.getKeyBindings()).toContainEqual({
     command: 'Editor.addCursorAbove',


### PR DESCRIPTION
Adds Shift+Enter as the previous-match shortcut while preserving Enter as next-match.

Regression coverage includes the keybinding table and a browser-path e2e that verifies Enter moves forward, Shift+Enter moves backward, focus stays in the query input, and neither the query nor document is modified.