### PR TITLE
fix: render diagnostic squiggles

### DIFF
--- a/packages/editor-worker/src/parts/RenderIncremental/RenderIncremental.ts
+++ b/packages/editor-worker/src/parts/RenderIncremental/RenderIncremental.ts
@@ -5,12 +5,15 @@ import { getEditorVirtualDom } from '../GetEditorVirtualDom/GetEditorVirtualDom.
 import * as RenderedDoms from '../RenderedDoms/RenderedDoms.ts'
 
 const getDom = (state: EditorState): readonly VirtualDomNode[] => {
-  const { initial, textInfos } = state
+  const { initial, textInfos, visualDecorations = [] } = state
   if (initial && textInfos.length === 0) {
     return []
   }
 
-  return getEditorVirtualDom(state)
+  return getEditorVirtualDom({
+    ...state,
+    diagnostics: visualDecorations,
+  })
 }
 
 export const renderIncremental = (oldState: EditorState, newState: EditorState): any => {

--- a/packages/editor-worker/test/RenderIncremental.test.ts
+++ b/packages/editor-worker/test/RenderIncremental.test.ts
@@ -136,3 +136,45 @@ test('renderIncremental diffs from the last emitted dom when editor state is mut
   expect(command[1]).toBe(1)
   expect(command[2]).not.toEqual([])
 })
+
+test('renderIncremental renders measured diagnostic decorations', () => {
+  const initialState = createState(0, [])
+  initialState.initial = true
+  const renderedState = {
+    ...createState(0, [['x', 'Token Identifier']]),
+    diagnostics: [
+      {
+        columnIndex: 0,
+        endColumnIndex: 1,
+        endRowIndex: 0,
+        message: "Type 'string' is not assignable to type 'number'.",
+        rowIndex: 0,
+        type: 'error',
+      },
+    ],
+    visualDecorations: [
+      {
+        height: 20,
+        type: 'error',
+        width: 9,
+        x: 0,
+        y: 0,
+      },
+    ],
+  }
+
+  const command = RenderIncremental.renderIncremental(initialState, renderedState)
+
+  expect(command[2]).toContainEqual({
+    nodes: expect.arrayContaining([
+      expect.objectContaining({
+        className: 'Diagnostic DiagnosticError',
+        height: 20,
+        left: 0,
+        top: 0,
+        width: 9,
+      }),
+    ]),
+    type: 6,
+  })
+})


### PR DESCRIPTION
Render measured diagnostic decorations during the editor's initial incremental DOM pass so error squiggles receive their position and size.