### PR TITLE
feature: pass cursor offset to source actions

### DIFF
--- a/packages/editor-worker/src/parts/GetSourceActions/GetSourceActions.ts
+++ b/packages/editor-worker/src/parts/GetSourceActions/GetSourceActions.ts
@@ -1,13 +1,15 @@
 import * as Editors from '../EditorStates/EditorStates.ts'
 import * as ExtensionHostEditor from '../ExtensionHostEditor/ExtensionHostEditor.ts'
+import * as GetOffsetAtCursor from '../GetOffsetAtCursor/GetOffsetAtCursor.ts'
 
 export const getEditorSourceActions = async (editorId?: number): Promise<readonly any[]> => {
   if (!editorId) {
     return []
   }
   const { newState } = Editors.get(editorId)
+  const offset = GetOffsetAtCursor.getOffsetAtCursor(newState)
   return ExtensionHostEditor.execute({
-    args: [],
+    args: [offset],
     editor: newState,
     event: 'onLanguage',
     method: 'ExtensionHostCodeActions.getSourceActions',

--- a/packages/editor-worker/test/GetSourceActions.test.ts
+++ b/packages/editor-worker/test/GetSourceActions.test.ts
@@ -20,6 +20,8 @@ test('getEditorSourceActions executes the activated extension-host provider', as
     ...emptyEditor,
     id: editorId,
     languageId: 'typescript',
+    lines: ['const value = unknownName'],
+    selections: new Uint32Array([0, 14, 0, 14]),
     uid: editorId,
     widgets: [],
   }
@@ -35,7 +37,7 @@ test('getEditorSourceActions executes the activated extension-host provider', as
 
   await expect(getEditorSourceActions(editorId)).resolves.toBe(actions)
   expect(executeMock).toHaveBeenCalledWith({
-    args: [],
+    args: [14],
     editor,
     event: 'onLanguage',
     method: 'ExtensionHostCodeActions.getSourceActions',


### PR DESCRIPTION
Passes the active editor cursor offset to code-action providers so they can return context-specific quick fixes.