### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import * as tsconfig from '@lvce-editor/eslint-plugin-tsconfig'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
   ...tsconfig.default,
   {
@@ -77,6 +78,47 @@ export default [
       'sonarjs/regex-complexity': 'off',
       'sonarjs/single-char-in-character-classes': 'off',
       'devcontainer/post-create-command': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/editor-worker/src/parts/{ColorPickerWorker,EditorCommand,EditorCompletionDetailWidget,EditorFolding,EditorScrolling,EditorSourceActionFocusNext,HandleSettingsChanged,HandleWheel,HotReload,HoverWorker,LoadContent,LoadHoverContent,MeasureTextWidthState,RenameWorker,Resize,SafeTokenizeLine,SourceActionWorker,SyncIncremental,SyntaxHighlightingState,TextDocument,TokenizerState}/**/*.ts',
+    ],
+    rules: {
+      'virtual-dom/prefer-state-destructuring': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/editor-worker/src/parts/EditorCommand/{EditorCommandDeleteHorizontal,EditorCommandMoveLineDown,EditorCommandMoveLineUp,EditorIndent}.ts',
+      'packages/editor-worker/src/parts/EditorCommand/EditorCommandSave/showSaveErrorDialog.ts',
+    ],
+    rules: {
+      'virtual-dom/no-object-attribute-values': 'off',
+      'virtual-dom/prefer-constants': 'off',
+    },
+  },
+  {
+    files: ['packages/editor-worker/src/parts/EditorMessageWidget/**/*.ts'],
+    rules: {
+      'virtual-dom/no-inline-style': 'off',
+    },
+  },
+  {
+    files: ['packages/editor-worker/src/parts/GetSearchToggleButtonVirtualDom/**/*.ts'],
+    rules: {
+      'virtual-dom/no-inline-event-handlers': 'off',
+    },
+  },
+  {
+    files: ['packages/editor-worker/test/**/*.ts'],
+    rules: {
+      'virtual-dom/no-inline-style': 'off',
+      'virtual-dom/no-object-attribute-values': 'off',
+      'virtual-dom/no-raw-text-children': 'off',
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
     },
   },
   {

--- a/packages/editor-worker/src/parts/AriaBoolean/AriaBoolean.ts
+++ b/packages/editor-worker/src/parts/AriaBoolean/AriaBoolean.ts
@@ -1,0 +1,1 @@
+export const True = 'true'

--- a/packages/editor-worker/src/parts/AriaRoles/AriaRoles.ts
+++ b/packages/editor-worker/src/parts/AriaRoles/AriaRoles.ts
@@ -1,4 +1,7 @@
+export const Button = 'button'
 export const Checkbox = 'checkbox'
+export const Code = 'code'
 export const Group = 'group'
 export const None = 'none'
 export const Option = 'option'
+export const TextBox = 'textbox'

--- a/packages/editor-worker/src/parts/EditorMessageWidget/EditorMessageWidget.ts
+++ b/packages/editor-worker/src/parts/EditorMessageWidget/EditorMessageWidget.ts
@@ -1,5 +1,6 @@
 import type { Widget } from '../Widget/Widget.ts'
 import * as AddWidget from '../AddWidget/AddWidget.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as RenderMethod from '../RenderMethod/RenderMethod.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
@@ -18,7 +19,7 @@ export const render = (widget: MessageWidget): readonly any[] => {
   const dom = [
     {
       childCount: 1,
-      className: 'Viewlet EditorMessage EditorMessageText EditorOverlayMessage',
+      className: MergeClassNames.mergeClassNames('Viewlet', 'EditorMessage', 'EditorMessageText', 'EditorOverlayMessage'),
       style: `left:${x}px;top:${y}px;`,
       type: VirtualDomElements.Div,
     },

--- a/packages/editor-worker/src/parts/GetCompletionDetailVirtualDom/GetCompletionDetailVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetCompletionDetailVirtualDom/GetCompletionDetailVirtualDom.ts
@@ -1,5 +1,8 @@
+import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
@@ -7,7 +10,7 @@ export const getCompletionDetailVirtualDom = (content: string) => {
   const dom: any[] = [
     {
       childCount: 2,
-      className: 'Viewlet EditorCompletionDetails',
+      className: MergeClassNames.mergeClassNames('Viewlet', 'EditorCompletionDetails'),
       type: VirtualDomElements.Div,
     },
     {
@@ -20,11 +23,13 @@ export const getCompletionDetailVirtualDom = (content: string) => {
       childCount: 1,
       className: ClassNames.CompletionDetailCloseButton,
       onClick: DomEventListenerFunctions.HandleClose,
+      role: AriaRoles.Button,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     {
       childCount: 0,
-      className: `${ClassNames.MaskIcon} ${ClassNames.IconClose}`,
+      className: MergeClassNames.mergeClassNames(ClassNames.MaskIcon, ClassNames.IconClose),
       type: VirtualDomElements.Div,
     },
   ]

--- a/packages/editor-worker/src/parts/GetCompletionItemIconVirtualDom/GetCompletionItemIconVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetCompletionItemIconVirtualDom/GetCompletionItemIconVirtualDom.ts
@@ -1,5 +1,6 @@
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as GetFileIconVirtualDom from '../GetFileIconVirtualDom/GetFileIconVirtualDom.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getIconDom = (fileIcon: string, symbolName: string) => {
@@ -8,7 +9,7 @@ export const getIconDom = (fileIcon: string, symbolName: string) => {
   }
   return {
     childCount: 0,
-    className: `${ClassNames.ColoredMaskIcon} ${symbolName}`,
+    className: MergeClassNames.mergeClassNames(ClassNames.ColoredMaskIcon, symbolName),
     type: VirtualDomElements.Div,
   }
 }

--- a/packages/editor-worker/src/parts/GetEditorInputVirtualDom/GetEditorInputVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorInputVirtualDom/GetEditorInputVirtualDom.ts
@@ -1,4 +1,6 @@
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
+import * as AriaBoolean from '../AriaBoolean/AriaBoolean.ts'
+import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
@@ -11,7 +13,7 @@ export const getEditorInputVirtualDom = (): readonly VirtualDomNode[] => {
     },
     {
       ariaAutoComplete: 'list',
-      ariaMultiLine: 'true',
+      ariaMultiLine: AriaBoolean.True,
       ariaRoleDescription: 'editor',
       autocapitalize: 'off',
       autocomplete: 'off',
@@ -26,7 +28,7 @@ export const getEditorInputVirtualDom = (): readonly VirtualDomNode[] => {
       onCut: DomEventListenerFunctions.HandleCut,
       onFocus: DomEventListenerFunctions.HandleFocus,
       onPaste: DomEventListenerFunctions.HandlePaste,
-      role: 'textbox',
+      role: AriaRoles.TextBox,
       spellcheck: false,
       type: VirtualDomElements.TextArea,
       wrap: 'off',

--- a/packages/editor-worker/src/parts/GetEditorMessageVirtualDom/GetEditorMessageVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorMessageVirtualDom/GetEditorMessageVirtualDom.ts
@@ -1,4 +1,5 @@
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
@@ -6,7 +7,7 @@ export const getEditorMessageVirtualDom = (message: string): readonly VirtualDom
   const dom: readonly VirtualDomNode[] = [
     {
       childCount: 2,
-      className: 'Viewlet EditorMessage',
+      className: MergeClassNames.mergeClassNames('Viewlet', 'EditorMessage'),
       tabIndex: -1,
       type: VirtualDomElements.Div,
     },

--- a/packages/editor-worker/src/parts/GetEditorVirtualDom/GetEditorVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorVirtualDom/GetEditorVirtualDom.ts
@@ -1,8 +1,10 @@
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
+import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as GetEditorContentVirtualDom from '../GetEditorContentVirtualDom/GetEditorContentVirtualDom.ts'
 import * as GetEditorGutterLayerVirtualDom from '../GetEditorGutterLayerVirtualDom/GetEditorGutterLayerVirtualDom.ts'
 import { getGutterInfos } from '../GetGutterInfos/GetGutterInfos.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
@@ -50,14 +52,14 @@ export const getEditorVirtualDom = ({
     return [
       {
         childCount: 2,
-        className: 'Viewlet TextEditorError',
+        className: MergeClassNames.mergeClassNames('Viewlet', 'TextEditorError'),
         'data-uid': uid,
-        role: 'code',
+        role: AriaRoles.Code,
         type: VirtualDomElements.Div,
       },
       {
         childCount: 0,
-        className: 'EditorTextIcon EditorTextIconError MaskIcon MaskIconError',
+        className: MergeClassNames.mergeClassNames('EditorTextIcon', 'EditorTextIconError', 'MaskIcon', 'MaskIconError'),
         type: VirtualDomElements.Div,
       },
       {
@@ -75,10 +77,10 @@ export const getEditorVirtualDom = ({
   return [
     {
       childCount: showGutter ? 2 : 1,
-      className: 'Viewlet Editor',
+      className: MergeClassNames.mergeClassNames('Viewlet', 'Editor'),
       'data-uid': uid,
       onContextMenu: DomEventListenerFunctions.HandleContextMenu,
-      role: 'code',
+      role: AriaRoles.Code,
       type: VirtualDomElements.Div,
     },
     ...gutterDom,

--- a/packages/editor-worker/src/parts/GetHoverVirtualDom/GetHoverVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetHoverVirtualDom/GetHoverVirtualDom.ts
@@ -2,6 +2,7 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as GetLineInfosVirtualDom from '../GetLineInfosVirtualDom/GetLineInfosVirtualDom.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
@@ -27,13 +28,13 @@ export const getHoverVirtualDom = (lineInfos: any, documentation: any, diagnosti
   const dom: VirtualDomNode[] = []
   dom.push({
     childCount: getChildCount(lineInfos, documentation, diagnostics) + 1,
-    className: 'Viewlet EditorHover',
+    className: MergeClassNames.mergeClassNames('Viewlet', 'EditorHover'),
     type: VirtualDomElements.Div,
   })
   if (diagnostics && diagnostics.length > 0) {
     dom.push({
       childCount: diagnostics.length * 2,
-      className: `${ClassNames.HoverDisplayString} ${ClassNames.HoverProblem}`,
+      className: MergeClassNames.mergeClassNames(ClassNames.HoverDisplayString, ClassNames.HoverProblem),
       type: VirtualDomElements.Div,
     })
     for (const diagnostic of diagnostics) {
@@ -66,7 +67,7 @@ export const getHoverVirtualDom = (lineInfos: any, documentation: any, diagnosti
 
   dom.push({
     childCount: 0,
-    className: 'Sash SashVertical SashResize',
+    className: MergeClassNames.mergeClassNames('Sash', 'SashVertical', 'SashResize'),
     onPointerDown: DomEventListenerFunctions.HandleSashPointerDown,
     type: VirtualDomElements.Div,
   })

--- a/packages/editor-worker/src/parts/GetIconVirtualDom/GetIconVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetIconVirtualDom/GetIconVirtualDom.ts
@@ -1,10 +1,11 @@
 import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getIconVirtualDom = (icon: string, type = VirtualDomElements.Div) => {
   return {
     childCount: 0,
-    className: `MaskIcon MaskIcon${icon}`,
+    className: MergeClassNames.mergeClassNames('MaskIcon', `MaskIcon${icon}`),
     role: AriaRoles.None,
     type,
   }

--- a/packages/editor-worker/src/parts/GetScrollBarVirtualDom/GetScrollBarVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetScrollBarVirtualDom/GetScrollBarVirtualDom.ts
@@ -1,30 +1,31 @@
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getScrollBarVirtualDom = (): readonly VirtualDomNode[] => {
   return [
     {
       childCount: 1,
-      className: 'ScrollBar ScrollBarVertical',
+      className: MergeClassNames.mergeClassNames('ScrollBar', 'ScrollBarVertical'),
       onContextMenu: DomEventListenerFunctions.HandleContextMenu,
       onPointerDown: DomEventListenerFunctions.HandleScrollBarVerticalPointerDown,
       type: VirtualDomElements.Div,
     },
     {
       childCount: 0,
-      className: 'ScrollBarThumb ScrollBarThumbVertical',
+      className: MergeClassNames.mergeClassNames('ScrollBarThumb', 'ScrollBarThumbVertical'),
       type: VirtualDomElements.Div,
     },
     {
       childCount: 1,
-      className: 'ScrollBar ScrollBarHorizontal',
+      className: MergeClassNames.mergeClassNames('ScrollBar', 'ScrollBarHorizontal'),
       onPointerDown: DomEventListenerFunctions.HandleScrollBarHorizontalPointerDown,
       type: VirtualDomElements.Div,
     },
     {
       childCount: 0,
-      className: 'ScrollBarThumb ScrollBarThumbHorizontal',
+      className: MergeClassNames.mergeClassNames('ScrollBarThumb', 'ScrollBarThumbHorizontal'),
       type: VirtualDomElements.Div,
     },
   ]

--- a/packages/editor-worker/src/parts/GetSearchFieldButtonVirtualDom/GetSearchFieldButtonVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetSearchFieldButtonVirtualDom/GetSearchFieldButtonVirtualDom.ts
@@ -2,6 +2,7 @@ import type { ISearchFieldButton } from '../ISearchFieldButton/ISearchFieldButto
 import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getSearchFieldButtonVirtualDom = (button: ISearchFieldButton) => {
@@ -12,7 +13,7 @@ export const getSearchFieldButtonVirtualDom = (button: ISearchFieldButton) => {
       childCount: 1,
       className: MergeClassNames.mergeClassNames(ClassNames.SearchFieldButton, checked ? ClassNames.SearchFieldButtonChecked : ''),
       role: AriaRoles.Checkbox,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       title,
       type: VirtualDomElements.Div,
     },

--- a/packages/editor-worker/src/parts/GetSearchToggleButtonVirtualDom/GetSearchToggleButtonVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetSearchToggleButtonVirtualDom/GetSearchToggleButtonVirtualDom.ts
@@ -1,5 +1,6 @@
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as InputName from '../InputName/InputName.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getSearchToggleButtonVirtualDom = (replaceExpanded: boolean, onClick = ''): readonly VirtualDomNode[] => {
@@ -8,7 +9,7 @@ export const getSearchToggleButtonVirtualDom = (replaceExpanded: boolean, onClic
       ariaExpanded: replaceExpanded,
       ariaLabel: 'Toggle Replace',
       childCount: 1,
-      className: `IconButton SearchToggleButton ${replaceExpanded ? 'SearchToggleButtonExpanded' : ''}`,
+      className: MergeClassNames.mergeClassNames('IconButton', 'SearchToggleButton', replaceExpanded ? 'SearchToggleButtonExpanded' : ''),
       'data-command': 'toggleReplace',
       name: InputName.ToggleReplace,
       onClick,
@@ -18,7 +19,7 @@ export const getSearchToggleButtonVirtualDom = (replaceExpanded: boolean, onClic
     },
     {
       childCount: 0,
-      className: `MaskIcon ${replaceExpanded ? 'MaskIconChevronDown' : 'MaskIconChevronRight'}`,
+      className: MergeClassNames.mergeClassNames('MaskIcon', replaceExpanded ? 'MaskIconChevronDown' : 'MaskIconChevronRight'),
       type: VirtualDomElements.Div,
     },
   ]

--- a/packages/editor-worker/src/parts/TabIndex/TabIndex.ts
+++ b/packages/editor-worker/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0


### PR DESCRIPTION
Enable the shared recommended virtual DOM ESLint preset.

Fix production renderer findings by using the existing class-name merger, named ARIA and tab-index constants, and accessible button semantics for the completion detail close control. Add narrow exceptions for editor state, RPC payload, dynamic-position style, legacy event wiring, and expected-DOM test fixtures that are not virtual DOM attributes.

Validation:
- `npm run lint`
- `npm run build`
- `npm run type-check`
- `npm test`
- `npm run measure` in `packages/build`