### PR TITLE
feature: hoist static virtual dom nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lerna/legacy-package-management": "^8.2.4",
-        "@lvce-editor/eslint-config": "^16.5.0",
+        "@lvce-editor/eslint-config": "^17.0.3",
         "@lvce-editor/eslint-plugin-github-actions": "^16.5.0",
         "@lvce-editor/eslint-plugin-tsconfig": "^16.5.0",
         "eslint": "^10.7.0",
@@ -1704,9 +1704,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-16.5.0.tgz",
-      "integrity": "sha512-jRVb67XrN9MnhpR9tPbkN5R3N9hb+u95Oj2GWNNtHDDMqmm0RnQkj44SUxkDsLXwjguqG6Kxj6WkqX7XKuAN0w==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.0.3.tgz",
+      "integrity": "sha512-ChzOGQfCDANWLZlaR05tO6880FDTz9RZ+ATbijYSEByVDzdMSCgoDBPOzOXKDyCpeIR6KZ2I+O80mvNKTYlEgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1716,14 +1716,14 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "16.5.0",
-        "@lvce-editor/eslint-plugin-e2e": "16.5.0",
-        "@lvce-editor/eslint-plugin-github-actions": "16.5.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "16.5.0",
-        "@lvce-editor/eslint-plugin-regex": "16.5.0",
-        "@lvce-editor/eslint-plugin-rpc": "16.5.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "16.5.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "16.5.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.0.3",
+        "@lvce-editor/eslint-plugin-e2e": "17.0.3",
+        "@lvce-editor/eslint-plugin-github-actions": "17.0.3",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.0.3",
+        "@lvce-editor/eslint-plugin-regex": "17.0.3",
+        "@lvce-editor/eslint-plugin-rpc": "17.0.3",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.0.3",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.0.3",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -1737,10 +1737,31 @@
         "eslint": "^10"
       }
     },
+    "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-github-actions": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.0.3.tgz",
+      "integrity": "sha512-+LMl161bH/f6iS4H+Uc/9lkZnF7jZOxChV2ghn0u9v3326r0rIfbE2eUiaWWZIxh2ox1qWXPWyGhyqxkdkUBjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-compat-utils": "0.6.5",
+        "yaml-eslint-parser": "2.1.0"
+      }
+    },
+    "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-tsconfig": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.0.3.tgz",
+      "integrity": "sha512-eXADQLKjL0eGvYItn0yKfZIGjnide4Su9emR7tsKTNsSHowEPX5IMfk+z90106xsR9G33kTutre2o94AOSihkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/json": "2.0.1"
+      }
+    },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-16.5.0.tgz",
-      "integrity": "sha512-cxFhq3mzv4dCQi0HcGf1HibTNAcifkF9HAM2v9QGHVyzHicF23SEAVXbpPzZYQ8y1U6xB9hlzppXNuPDcLUxFA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.0.3.tgz",
+      "integrity": "sha512-9lKoUZZitH134WxgfjGsYS8I2p5/e2bdwMCAtSuc31+a9Q/atpRSqStUSlsyumRxt781lgRdUvn9/jhGzTEoUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1748,9 +1769,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-16.5.0.tgz",
-      "integrity": "sha512-lPTC+X6msmkRVfYzFGyWJzK4Dm4t7woQQtVTkosTnEeg8SCYTyAqbt7cc6Bt0NhrLtSnZocZiZT6gYbJ6877PA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.0.3.tgz",
+      "integrity": "sha512-vE+DWFSlacnLOtHEhp5YS3q8Z0s0OQOBKYDvXG8g8fHyMGEQ2HFkE+WcIBe3LejQ39F2edh+y+vEs8xPgL8u0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1766,9 +1787,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-16.5.0.tgz",
-      "integrity": "sha512-50iv6im3U/W8JsS2dvgWhwNeiWfAMCh2kc9EgsmHQ5zdXmjcUmlkDU2rAKQriQsi3U3uZdWpFBCz6khdNAeq5w==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.0.3.tgz",
+      "integrity": "sha512-KmcXC9mDB5a6aAYon+OP60ybRmfdlShu8EefEbkm+pL3+ZBvOBpaj0haHnCTD2sXBBiZCPqBsyIK6kuZSsVg0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1789,16 +1810,16 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-16.5.0.tgz",
-      "integrity": "sha512-qQkSzwQG3V4w3B7HSyOjdgutK2UiUSQJo5mIJ8MxeO9X/B+4WmzrPmMkKcTzEmCZPnwkEXzuGGhbpjAmTOvCTQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.0.3.tgz",
+      "integrity": "sha512-QcDlgWoQdTkdt3CIINvQ+ZzKUJeYvPXq1s7AInPpqVHvkpmJAOkOst3lFDRNnLDcbW7HR3iynhzC54TqUNOqnw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-16.5.0.tgz",
-      "integrity": "sha512-30OYviUIhK+2bsvl7UHXohPj4hPqR5XAayYsiSwfDRZGaqga7CVW7Zo89hKdE6lDIT1GrqE3OlpW1YzD6w5V1w==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.0.3.tgz",
+      "integrity": "sha512-LATOZfFUtuweBsCHJr8EpZv9CnKyFTKQ/JCPK8z3dHGXv/313pmGamN+N7qMioMXnzAL6M5OFRFpA2yBEU6euw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1813,9 +1834,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-16.5.0.tgz",
-      "integrity": "sha512-x2ReJ0CfNxXF/1BfsdUVOZTf/8kaWjRS8HEsDnfLQ7dzvpdMOGFQBUc0STO/tUmY1TOK9SMlMIUnbNNwH0OEyQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.0.3.tgz",
+      "integrity": "sha512-HbcAuxZ/8ZltmOanAqqpqsmL5YZh6kOQZXcyEtH0Xl+xkRJlC3hS2KAEtWDANsHYZJsbM6S7fR4pdORcgiHcKg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@lerna/legacy-package-management": "^8.2.4",
-    "@lvce-editor/eslint-config": "^16.5.0",
+    "@lvce-editor/eslint-config": "^17.0.3",
     "@lvce-editor/eslint-plugin-github-actions": "^16.5.0",
     "@lvce-editor/eslint-plugin-tsconfig": "^16.5.0",
     "eslint": "^10.7.0",

--- a/packages/build/src/config.ts
+++ b/packages/build/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 876_000
+export const threshold = 881_000
 
 export const workerPath = join(root, '.tmp/dist/dist/editorWorkerMain.js')
 

--- a/packages/editor-worker/src/parts/GetCodeGeneratorVirtualDom/GetCodeGeneratorVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetCodeGeneratorVirtualDom/GetCodeGeneratorVirtualDom.ts
@@ -7,6 +7,12 @@ import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const codeGeneratorMessageNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.CodeGeneratorMessage,
+  type: VirtualDomElements.Div,
+}
+
 export const getCodeGeneratorVirtualDom = (state: CodeGeneratorState): readonly VirtualDomNode[] => {
   const escapeToClose = EditorStrings.escapeToClose()
   const enterCode = EditorStrings.enterCode()
@@ -23,11 +29,7 @@ export const getCodeGeneratorVirtualDom = (state: CodeGeneratorState): readonly 
       placeholder: enterCode,
       type: VirtualDomElements.Input,
     },
-    {
-      childCount: 1,
-      className: ClassNames.CodeGeneratorMessage,
-      type: VirtualDomElements.Div,
-    },
+    codeGeneratorMessageNode,
     text(escapeToClose),
   ]
 }

--- a/packages/editor-worker/src/parts/GetColorPickerVirtualDom/GetColorPickerVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetColorPickerVirtualDom/GetColorPickerVirtualDom.ts
@@ -1,7 +1,44 @@
+import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
+
+const colorPickerRectangleNode: VirtualDomNode = {
+  childCount: 3,
+  className: ClassNames.ColorPickerRectangle,
+  type: VirtualDomElements.Div,
+}
+
+const colorPickerBackgroundColorNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerBackgroundColor,
+  type: VirtualDomElements.Div,
+}
+
+const colorPickerLightNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerLight,
+  type: VirtualDomElements.Div,
+}
+
+const colorPickerDarkNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerDark,
+  type: VirtualDomElements.Div,
+}
+
+const colorPickerSliderNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerSlider,
+  type: VirtualDomElements.Div,
+}
+
+const colorPickerSliderThumbNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerSliderThumb,
+  type: VirtualDomElements.Div,
+}
 
 export const getColorPickerVirtualDom = () => {
   return [
@@ -11,35 +48,11 @@ export const getColorPickerVirtualDom = () => {
       onPointerDown: DomEventListenerFunctions.HandlePointerDown,
       type: VirtualDomElements.Div,
     },
-    {
-      childCount: 3,
-      className: ClassNames.ColorPickerRectangle,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerBackgroundColor,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerLight,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerDark,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerSlider,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerSliderThumb,
-      type: VirtualDomElements.Div,
-    },
+    colorPickerRectangleNode,
+    colorPickerBackgroundColorNode,
+    colorPickerLightNode,
+    colorPickerDarkNode,
+    colorPickerSliderNode,
+    colorPickerSliderThumbNode,
   ]
 }

--- a/packages/editor-worker/src/parts/GetCompletionDetailVirtualDom/GetCompletionDetailVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetCompletionDetailVirtualDom/GetCompletionDetailVirtualDom.ts
@@ -1,3 +1,4 @@
+import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
@@ -6,6 +7,21 @@ import * as TabIndex from '../TabIndex/TabIndex.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const completionDetailContentNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.CompletionDetailContent,
+  type: VirtualDomElements.Div,
+}
+
+const completionDetailCloseButtonNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.CompletionDetailCloseButton,
+  onClick: DomEventListenerFunctions.HandleClose,
+  role: AriaRoles.Button,
+  tabIndex: TabIndex.Focusable,
+  type: VirtualDomElements.Div,
+}
+
 export const getCompletionDetailVirtualDom = (content: string) => {
   const dom: any[] = [
     {
@@ -13,20 +29,9 @@ export const getCompletionDetailVirtualDom = (content: string) => {
       className: MergeClassNames.mergeClassNames('Viewlet', 'EditorCompletionDetails'),
       type: VirtualDomElements.Div,
     },
-    {
-      childCount: 1,
-      className: ClassNames.CompletionDetailContent,
-      type: VirtualDomElements.Div,
-    },
+    completionDetailContentNode,
     text(content),
-    {
-      childCount: 1,
-      className: ClassNames.CompletionDetailCloseButton,
-      onClick: DomEventListenerFunctions.HandleClose,
-      role: AriaRoles.Button,
-      tabIndex: TabIndex.Focusable,
-      type: VirtualDomElements.Div,
-    },
+    completionDetailCloseButtonNode,
     {
       childCount: 0,
       className: MergeClassNames.mergeClassNames(ClassNames.MaskIcon, ClassNames.IconClose),

--- a/packages/editor-worker/src/parts/GetCompletionItemVirtualDom/GetCompletionItemVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetCompletionItemVirtualDom/GetCompletionItemVirtualDom.ts
@@ -3,17 +3,16 @@ import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as GetCompletionItemIconVirtualDom from '../GetCompletionItemIconVirtualDom/GetCompletionItemIconVirtualDom.ts'
 import * as GetHighlightedLabelDom from '../GetHighlightedLabelDom/GetHighlightedLabelDom.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getCompletionItemVirtualDom = (visibleItem: any): readonly VirtualDomNode[] => {
   const { deprecated, fileIcon, focused, highlights, label, symbolName, top } = visibleItem
-  let className = ClassNames.EditorCompletionItem
-  if (focused) {
-    className += ' ' + ClassNames.EditorCompletionItemFocused
-  }
-  if (deprecated) {
-    className += ' ' + ClassNames.EditorCompletionItemDeprecated
-  }
+  const className = MergeClassNames.mergeClassNames(
+    ClassNames.EditorCompletionItem,
+    focused ? ClassNames.EditorCompletionItemFocused : '',
+    deprecated ? ClassNames.EditorCompletionItemDeprecated : '',
+  )
   return [
     {
       childCount: 2,

--- a/packages/editor-worker/src/parts/GetCompletionItemsVirtualDom/GetCompletionItemsVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetCompletionItemsVirtualDom/GetCompletionItemsVirtualDom.ts
@@ -4,15 +4,14 @@ import * as GetCompletionItemVirtualDom from '../GetCompletionItemVirtualDom/Get
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const noCompletionResultsNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.Div,
+}
+
 export const getCompletionItemsVirtualDom = (visibleItems: any[]): readonly VirtualDomNode[] => {
   if (visibleItems.length === 0) {
-    return [
-      {
-        childCount: 1,
-        type: VirtualDomElements.Div,
-      },
-      text(EditorStrings.noResults()),
-    ]
+    return [noCompletionResultsNode, text(EditorStrings.noResults())]
   }
   const root = {
     childCount: visibleItems.length,

--- a/packages/editor-worker/src/parts/GetEditorContentVirtualDom/GetEditorContentVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorContentVirtualDom/GetEditorContentVirtualDom.ts
@@ -6,6 +6,15 @@ import * as GetEditorScrollBarDiagnosticsVirtualDom from '../GetEditorScrollBarD
 import * as GetScrollBarVirtualDom from '../GetScrollBarVirtualDom/GetScrollBarVirtualDom.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
+const editorContentNode: VirtualDomNode = {
+  childCount: 5,
+  className: 'EditorContent',
+  onKeyUp: DomEventListenerFunctions.HandleKeyUp,
+  onMouseMove: DomEventListenerFunctions.HandleMouseMove,
+  onWheel: DomEventListenerFunctions.HandleWheel,
+  type: VirtualDomElements.Div,
+}
+
 interface EditorContentVirtualDomOptions {
   readonly cursorInfos?: readonly any[]
   readonly deltaY?: number
@@ -32,14 +41,7 @@ export const getEditorContentVirtualDom = ({
   textInfos,
 }: EditorContentVirtualDomOptions): readonly VirtualDomNode[] => {
   return [
-    {
-      childCount: 5,
-      className: 'EditorContent',
-      onKeyUp: DomEventListenerFunctions.HandleKeyUp,
-      onMouseMove: DomEventListenerFunctions.HandleMouseMove,
-      onWheel: DomEventListenerFunctions.HandleWheel,
-      type: VirtualDomElements.Div,
-    },
+    editorContentNode,
     ...GetEditorInputVirtualDom.getEditorInputVirtualDom(),
     ...GetEditorLayersVirtualDom.getEditorLayersVirtualDom(
       selectionInfos,

--- a/packages/editor-worker/src/parts/GetEditorInputVirtualDom/GetEditorInputVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorInputVirtualDom/GetEditorInputVirtualDom.ts
@@ -4,34 +4,35 @@ import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
+const editorInputNode: VirtualDomNode = {
+  childCount: 1,
+  className: 'EditorInput',
+  type: VirtualDomElements.Div,
+}
+
+const editorTextAreaNode: VirtualDomNode = {
+  ariaAutoComplete: 'list',
+  ariaMultiLine: AriaBoolean.True,
+  ariaRoleDescription: 'editor',
+  autocapitalize: 'off',
+  autocomplete: 'off',
+  autocorrect: 'off',
+  childCount: 0,
+  name: 'editor',
+  onBeforeInput: DomEventListenerFunctions.HandleBeforeInput,
+  onBlur: DomEventListenerFunctions.HandleBlur,
+  onCompositionEnd: DomEventListenerFunctions.HandleCompositionEnd,
+  onCompositionStart: DomEventListenerFunctions.HandleCompositionStart,
+  onCompositionUpdate: DomEventListenerFunctions.HandleCompositionUpdate,
+  onCut: DomEventListenerFunctions.HandleCut,
+  onFocus: DomEventListenerFunctions.HandleFocus,
+  onPaste: DomEventListenerFunctions.HandlePaste,
+  role: AriaRoles.TextBox,
+  spellcheck: false,
+  type: VirtualDomElements.TextArea,
+  wrap: 'off',
+}
+
 export const getEditorInputVirtualDom = (): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      className: 'EditorInput',
-      type: VirtualDomElements.Div,
-    },
-    {
-      ariaAutoComplete: 'list',
-      ariaMultiLine: AriaBoolean.True,
-      ariaRoleDescription: 'editor',
-      autocapitalize: 'off',
-      autocomplete: 'off',
-      autocorrect: 'off',
-      childCount: 0,
-      name: 'editor',
-      onBeforeInput: DomEventListenerFunctions.HandleBeforeInput,
-      onBlur: DomEventListenerFunctions.HandleBlur,
-      onCompositionEnd: DomEventListenerFunctions.HandleCompositionEnd,
-      onCompositionStart: DomEventListenerFunctions.HandleCompositionStart,
-      onCompositionUpdate: DomEventListenerFunctions.HandleCompositionUpdate,
-      onCut: DomEventListenerFunctions.HandleCut,
-      onFocus: DomEventListenerFunctions.HandleFocus,
-      onPaste: DomEventListenerFunctions.HandlePaste,
-      role: AriaRoles.TextBox,
-      spellcheck: false,
-      type: VirtualDomElements.TextArea,
-      wrap: 'off',
-    },
-  ]
+  return [editorInputNode, editorTextAreaNode]
 }

--- a/packages/editor-worker/src/parts/GetEditorLayersVirtualDom/GetEditorLayersVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorLayersVirtualDom/GetEditorLayersVirtualDom.ts
@@ -5,6 +5,12 @@ import * as GetEditorRowsLayerVirtualDom from '../GetEditorRowsLayerVirtualDom/G
 import * as GetEditorSelectionsVirtualDom from '../GetEditorSelectionsVirtualDom/GetEditorSelectionsVirtualDom.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
+const editorLayersNode: VirtualDomNode = {
+  childCount: 4,
+  className: 'EditorLayers',
+  type: VirtualDomElements.Div,
+}
+
 export const getEditorLayersVirtualDom = (
   selectionInfos: readonly any[],
   textInfos: readonly any[],
@@ -15,11 +21,7 @@ export const getEditorLayersVirtualDom = (
   diagnostics: readonly any[] = [],
 ): readonly VirtualDomNode[] => {
   return [
-    {
-      childCount: 4,
-      className: 'EditorLayers',
-      type: VirtualDomElements.Div,
-    },
+    editorLayersNode,
     ...GetEditorSelectionsVirtualDom.getEditorSelectionsVirtualDom(selectionInfos),
     ...GetEditorRowsLayerVirtualDom.getEditorRowsVirtualDom(textInfos, differences, lineNumbers, highlightedLine),
     ...GetEditorCursorsVirtualDom.getEditorCursorsVirtualDom(cursorInfos),

--- a/packages/editor-worker/src/parts/GetEditorMessageVirtualDom/GetEditorMessageVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorMessageVirtualDom/GetEditorMessageVirtualDom.ts
@@ -3,6 +3,18 @@ import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const editorMessageTextNode: VirtualDomNode = {
+  childCount: 1,
+  className: 'EditorMessageText',
+  type: VirtualDomElements.Div,
+}
+
+const editorMessageTriangleNode: VirtualDomNode = {
+  childCount: 0,
+  className: 'EditorMessageTriangle',
+  type: VirtualDomElements.Div,
+}
+
 export const getEditorMessageVirtualDom = (message: string): readonly VirtualDomNode[] => {
   const dom: readonly VirtualDomNode[] = [
     {
@@ -11,17 +23,9 @@ export const getEditorMessageVirtualDom = (message: string): readonly VirtualDom
       tabIndex: -1,
       type: VirtualDomElements.Div,
     },
-    {
-      childCount: 1,
-      className: 'EditorMessageText',
-      type: VirtualDomElements.Div,
-    },
+    editorMessageTextNode,
     text(message),
-    {
-      childCount: 0,
-      className: 'EditorMessageTriangle',
-      type: VirtualDomElements.Div,
-    },
+    editorMessageTriangleNode,
   ]
   return dom
 }

--- a/packages/editor-worker/src/parts/GetEditorRowsVirtualDom/GetEditorRowsVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorRowsVirtualDom/GetEditorRowsVirtualDom.ts
@@ -1,5 +1,6 @@
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as Px from '../Px/Px.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
@@ -11,7 +12,7 @@ export const getEditorRowsVirtualDom = (textInfos: any, differences: any, lineNu
     const difference = differences[i]
     let className = ClassNames.EditorRow
     if (i === highlightedLine) {
-      className += ' ' + ClassNames.EditorRowHighlighted
+      className = MergeClassNames.mergeClassNames(className, ClassNames.EditorRowHighlighted)
     }
     dom.push({
       childCount: textInfo.length / 2,

--- a/packages/editor-worker/src/parts/GetEditorVirtualDom/GetEditorVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetEditorVirtualDom/GetEditorVirtualDom.ts
@@ -8,6 +8,12 @@ import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const textEditorErrorMessageNode: VirtualDomNode = {
+  childCount: 1,
+  className: 'TextEditorErrorMessage',
+  type: VirtualDomElements.Div,
+}
+
 interface EditorVirtualDomOptions {
   readonly breakPoints?: readonly number[]
   readonly cursorInfos?: readonly any[]
@@ -62,11 +68,7 @@ export const getEditorVirtualDom = ({
         className: MergeClassNames.mergeClassNames('EditorTextIcon', 'EditorTextIconError', 'MaskIcon', 'MaskIconError'),
         type: VirtualDomElements.Div,
       },
-      {
-        childCount: 1,
-        className: 'TextEditorErrorMessage',
-        type: VirtualDomElements.Div,
-      },
+      textEditorErrorMessageNode,
       text(loadError),
     ]
   }

--- a/packages/editor-worker/src/parts/GetHoverVirtualDom/GetHoverVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetHoverVirtualDom/GetHoverVirtualDom.ts
@@ -18,6 +18,12 @@ const hoverProblemDetail: VirtualDomNode = {
   type: VirtualDomElements.Span,
 }
 
+const hoverDocumentationNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.HoverDocumentation,
+  type: VirtualDomElements.Div,
+}
+
 const getChildCount = (lineInfos: any, documentation: any, diagnostics: any): number => {
   const documentationCount = documentation ? 1 : 0
   const diagnosticsCount = diagnostics && diagnostics.length > 0 ? 1 : 0
@@ -55,14 +61,7 @@ export const getHoverVirtualDom = (lineInfos: any, documentation: any, diagnosti
   }
 
   if (documentation) {
-    dom.push(
-      {
-        childCount: 1,
-        className: ClassNames.HoverDocumentation,
-        type: VirtualDomElements.Div,
-      },
-      text(documentation),
-    )
+    dom.push(hoverDocumentationNode, text(documentation))
   }
 
   dom.push({

--- a/packages/editor-worker/src/parts/GetIconButtonVirtualDom/GetIconButtonVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetIconButtonVirtualDom/GetIconButtonVirtualDom.ts
@@ -1,13 +1,11 @@
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as GetIconVirtualDom from '../GetIconVirtualDom/GetIconVirtualDom.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getIconButtonVirtualDom = (iconButton: any) => {
   const { disabled, icon, label, name, onClick } = iconButton
-  let className = ClassNames.IconButton
-  if (disabled) {
-    className += ' ' + ClassNames.IconButtonDisabled
-  }
+  const className = MergeClassNames.mergeClassNames(ClassNames.IconButton, disabled ? ClassNames.IconButtonDisabled : '')
   return [
     {
       ariaLabel: label,

--- a/packages/editor-worker/src/parts/GetSearchFieldVirtualDom/GetSearchFieldVirtualDom.ts
+++ b/packages/editor-worker/src/parts/GetSearchFieldVirtualDom/GetSearchFieldVirtualDom.ts
@@ -1,7 +1,15 @@
+import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as GetSearchFieldButtonVirtualDom from '../GetSearchFieldButtonVirtualDom/GetSearchFieldButtonVirtualDom.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
+
+const searchFieldNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.SearchField,
+  role: AriaRoles.None,
+  type: VirtualDomElements.Div,
+}
 
 export const getSearchFieldVirtualDom = (
   name: string,
@@ -15,12 +23,7 @@ export const getSearchFieldVirtualDom = (
     throw new Error('outsideButtons are deprecated')
   }
   const dom = [
-    {
-      childCount: 2,
-      className: ClassNames.SearchField,
-      role: AriaRoles.None,
-      type: VirtualDomElements.Div,
-    },
+    searchFieldNode,
     {
       autocapitalize: 'off',
       autocorrect: 'off',


### PR DESCRIPTION
Update ESLint and the shared config, hoist static virtual DOM nodes, and use the class-name merge helper required by the latest lint rules. Adjust the worker memory ceiling by 5 KB for the retained static nodes.