### PR TITLE
fix: align diagnostic squiggles

### DIFF
--- a/packages/e2e/src/editor.diagnostic-squiggle-row.ts
+++ b/packages/e2e/src/editor.diagnostic-squiggle-row.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.diagnostic-squiggle-row'
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/test.txt`, 'first\nsecond')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/test.txt`)
+
+  await Command.execute('Editor.setDiagnostics', [
+    {
+      code: 1,
+      columnIndex: 0,
+      endColumnIndex: 1,
+      endRowIndex: 1,
+      message: 'error',
+      rowIndex: 1,
+      source: 'test',
+      type: 'error',
+      uri: `${tmpDir}/test.txt`,
+    },
+  ])
+
+  const diagnostic = Locator('.Diagnostic')
+  await expect(diagnostic).toHaveCSS('top', '20px')
+}

--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -358,6 +358,7 @@ export const commandMap = {
   'Editor.setDecorations': wrapCommand(SetDecorations.setDecorations),
   'Editor.setDelta': wrapCommand(SetDelta.setDelta),
   'Editor.setDeltaY': wrapCommand(SetDelta.setDeltaY),
+  'Editor.setDiagnostics': wrapCommand(UpdateDiagnostics.addDiagnostics),
   'Editor.setLanguageId': wrapCommand(SetLanguageId.setLanguageId),
   'Editor.setSelections': wrapCommand(SetSelections.setSelections),
   'Editor.setSelections2': ExternalGetPositionAtCursor.setSelections2,

--- a/packages/editor-worker/src/parts/GetVisibleDiagnostics/GetVisibleDiagnostics.ts
+++ b/packages/editor-worker/src/parts/GetVisibleDiagnostics/GetVisibleDiagnostics.ts
@@ -26,7 +26,7 @@ export const getVisibleDiagnostics = async (editor: any, diagnostics: readonly D
       charWidth,
       endLineDifference,
     )
-    const y = GetY.getY(rowIndex, minLineY, rowHeight) - rowHeight
+    const y = GetY.getY(rowIndex, minLineY, rowHeight)
     visibleDiagnostics.push({
       height: rowHeight,
       type: GetDiagnosticType.getDiagnosticType(diagnostic),

--- a/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
+++ b/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
@@ -15,7 +15,7 @@ const getDiagnostics = async (editor: any): Promise<readonly any[]> => {
   return ExtensionHostDiagnostic.executeDiagnosticProvider(editor)
 }
 
-const addDiagnostics = async (editor: any, diagnostics: readonly any[]): Promise<any> => {
+export const addDiagnostics = async (editor: any, diagnostics: readonly any[]): Promise<any> => {
   const visualDecorations = await GetVisibleDiagnostics.getVisibleDiagnostics(editor, diagnostics)
   const diagnosticDecorations = visualDecorations.flatMap((decoration: any) => [
     decoration.offset,

--- a/packages/editor-worker/test/GetVisibleDiagnostics.test.ts
+++ b/packages/editor-worker/test/GetVisibleDiagnostics.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@jest/globals'
+import { getVisibleDiagnostics } from '../src/parts/GetVisibleDiagnostics/GetVisibleDiagnostics.ts'
+
+test('renders a diagnostic on its reported row', async () => {
+  const editor = {
+    charWidth: 8,
+    fontFamily: 'monospace',
+    fontSize: 14,
+    fontWeight: 400,
+    isMonospaceFont: true,
+    letterSpacing: 0,
+    lines: ['first', 'second'],
+    minLineY: 0,
+    rowHeight: 20,
+    tabSize: 2,
+    width: 800,
+  }
+  const diagnostics = [
+    {
+      code: 1,
+      columnIndex: 0,
+      endColumnIndex: 1,
+      endRowIndex: 1,
+      message: 'error',
+      rowIndex: 1,
+      source: 'test',
+      type: 'error',
+      uri: '/test.xyz',
+    },
+  ]
+
+  await expect(getVisibleDiagnostics(editor, diagnostics)).resolves.toEqual([
+    {
+      height: 20,
+      type: 'error',
+      width: 8,
+      x: 0,
+      y: 20,
+    },
+  ])
+})


### PR DESCRIPTION
Fixes diagnostic decorations rendering one row above their reported source range. Enables an end-to-end regression that verifies the rendered squiggle position.