### PR TITLE
fix: load editor before diagnostics

### DIFF
--- a/packages/editor-worker/src/parts/CreateEditor/CreateEditor.ts
+++ b/packages/editor-worker/src/parts/CreateEditor/CreateEditor.ts
@@ -16,7 +16,6 @@ import * as LinkDetection from '../LinkDetection/LinkDetection.ts'
 import * as MeasureCharacterWidth from '../MeasureCharacterWidth/MeasureCharacterWidth.ts'
 import * as Preferences from '../Preferences/Preferences.ts'
 import * as SyncIncremental from '../SyncIncremental/SyncIncremental.ts'
-import * as UpdateDiagnostics from '../UpdateDiagnostics/UpdateDiagnostics.ts'
 
 export const createEditor = async ({
   assetDir,
@@ -177,12 +176,10 @@ export const createEditor = async ({
   // @ts-ignore
   await ExtensionHostWorker.invoke(ExtensionHostCommandType.TextDocumentSyncFull, uri, id, languageId, content)
 
-  const editorWithDiagnostics = diagnosticsEnabled ? await UpdateDiagnostics.updateDiagnostics(newEditor4) : newEditor4
-
   const completionsOnTypeRaw = await Preferences.get('editor.completionsOnType')
   const completionsOnType = Boolean(completionsOnTypeRaw)
   EditorState.set(id, emptyEditor, {
-    ...editorWithDiagnostics,
+    ...newEditor4,
     completionsOnType,
   })
 }

--- a/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
@@ -15,7 +15,6 @@ import * as SyncIncremental from '../SyncIncremental/SyncIncremental.ts'
 import * as Tokenizer from '../Tokenizer/Tokenizer.ts'
 import * as TokenizerMap from '../TokenizerMap/TokenizerMap.ts'
 import * as TokenizerState from '../TokenizerState/TokenizerState.ts'
-import * as UpdateDiagnostics from '../UpdateDiagnostics/UpdateDiagnostics.ts'
 
 const getTokenizePath = (languages: readonly any[], languageId: string): string => {
   for (const language of languages) {
@@ -123,12 +122,10 @@ export const loadContent = async (state: EditorState, savedState: unknown) => {
   // @ts-ignore
   await ExtensionHostWorker.invoke(ExtensionHostCommandType.TextDocumentSyncFull, uri, id, computedLanguageId, content)
 
-  const editorWithDiagnostics = diagnosticsEnabled ? await UpdateDiagnostics.getEditorWithDiagnostics(newEditor4) : newEditor4
-
   const completionsOnTypeRaw = await Preferences.get('editor.completionsOnType')
   const completionsOnType = Boolean(completionsOnTypeRaw)
   const newEditor5: EditorState = {
-    ...editorWithDiagnostics,
+    ...newEditor4,
     completionsOnType,
     initial: false,
   }

--- a/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
+++ b/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
@@ -1,4 +1,3 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as EditorState from '../EditorStates/EditorStates.ts'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.ts'
 import * as ExtensionHostCommandType from '../ExtensionHostCommandType/ExtensionHostCommandType.ts'
@@ -40,19 +39,10 @@ const handleError = async (error: unknown, editor: any): Promise<any> => {
   return editor
 }
 
-export const getEditorWithDiagnostics = async (editor: any): Promise<any> => {
-  try {
-    const diagnostics = await getDiagnostics(editor)
-    if (!EditorState.get(editor.id)) {
-      return editor
-    }
-    return addDiagnostics(editor, diagnostics)
-  } catch (error) {
-    return handleError(error, editor)
-  }
-}
-
 export const updateDiagnostics = async (editor: any): Promise<any> => {
+  if (!editor.diagnosticsEnabled) {
+    return editor
+  }
   try {
     const diagnostics = await getDiagnostics(editor)
     const latest = EditorState.get(editor.id)
@@ -61,8 +51,6 @@ export const updateDiagnostics = async (editor: any): Promise<any> => {
     }
     const newEditor = await addDiagnostics(latest.newState, diagnostics)
     EditorState.set(editor.id, latest.oldState, newEditor)
-    // @ts-ignore
-    await RendererWorker.invoke('Editor.rerender', editor.id)
     return newEditor
   } catch (error) {
     return handleError(error, editor)

--- a/packages/editor-worker/test/LoadContent.test.ts
+++ b/packages/editor-worker/test/LoadContent.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
+const extensionManagementWorkerInvoke = jest.fn()
 const getEditorPreferencesMock: any = jest.fn()
-const getEditorWithDiagnosticsMock: any = jest.fn()
 const getLanguagesMock: any = jest.fn()
 const getVisibleMock: any = jest.fn()
 const getTokenizerMock: any = jest.fn()
@@ -16,7 +16,7 @@ jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
     set: jest.fn(),
   },
   ExtensionManagementWorker: {
-    invoke: jest.fn(),
+    invoke: extensionManagementWorkerInvoke,
   },
   RendererWorker: {
     getPreference: jest.fn(),
@@ -54,10 +54,6 @@ jest.unstable_mockModule('../src/parts/MeasureCharacterWidth/MeasureCharacterWid
 jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.ts', () => ({
   getTokenizer: getTokenizerMock,
   loadTokenizer: loadTokenizerMock,
-}))
-
-jest.unstable_mockModule('../src/parts/UpdateDiagnostics/UpdateDiagnostics.ts', () => ({
-  getEditorWithDiagnostics: getEditorWithDiagnosticsMock,
 }))
 
 const LoadContent = await import('../src/parts/LoadContent/LoadContent.ts')
@@ -104,8 +100,8 @@ const createState = () =>
   }) as any
 
 beforeEach(() => {
+  extensionManagementWorkerInvoke.mockReset()
   getEditorPreferencesMock.mockReset()
-  getEditorWithDiagnosticsMock.mockReset()
   getLanguagesMock.mockReset()
   getVisibleMock.mockReset()
   getTokenizerMock.mockReset()
@@ -131,7 +127,6 @@ beforeEach(() => {
   getLanguagesMock.mockResolvedValue([{ extensions: ['.txt'], id: 'plaintext', tokenize: '' }])
   getVisibleMock.mockResolvedValue({ differences: [], textInfos: [] })
   getTokenizerMock.mockReturnValue({})
-  getEditorWithDiagnosticsMock.mockImplementation(async (editor: any) => editor)
   measureCharacterWidthMock.mockResolvedValue(8)
 })
 
@@ -148,8 +143,7 @@ test('loadContent returns error state when reading file fails', async () => {
   expect(readFileMock).toHaveBeenCalledWith('file:///test.txt')
 })
 
-test('loadContent preserves loaded text and diagnostics', async () => {
-  const diagnostics = [{ message: 'diagnostic' }]
+test('loadContent returns loaded text without requesting diagnostics', async () => {
   getEditorPreferencesMock.mockResolvedValue({
     completionTriggerCharacters: [],
     diagnosticsEnabled: true,
@@ -166,16 +160,11 @@ test('loadContent preserves loaded text and diagnostics', async () => {
     tabSize: 2,
   })
   readFileMock.mockResolvedValue('test')
-  getEditorWithDiagnosticsMock.mockImplementation(async (editor: any) => ({
-    ...editor,
-    diagnostics,
-  }))
 
   const result = await LoadContent.loadContent(createState(), undefined)
 
-  expect(result.diagnostics).toBe(diagnostics)
   expect(result.lines).toEqual(['test'])
-  expect(getEditorWithDiagnosticsMock).toHaveBeenCalledTimes(1)
+  expect(extensionManagementWorkerInvoke).not.toHaveBeenCalled()
 })
 
 test('loadContent uses a tokenizer from a later contribution for the same language', async () => {

--- a/packages/editor-worker/test/UpdateDiagnostics.test.ts
+++ b/packages/editor-worker/test/UpdateDiagnostics.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, expect, test } from '@jest/globals'
-import { ExtensionHost, registerMockRpc, remove, RpcId } from '@lvce-editor/rpc-registry'
-import { getEditorWithDiagnostics } from '../src/parts/UpdateDiagnostics/UpdateDiagnostics.ts'
+import { MockRpc } from '@lvce-editor/rpc'
+import { ExtensionHost, ExtensionManagementWorker, registerMockRpc, remove, RpcId } from '@lvce-editor/rpc-registry'
+import * as EditorStates from '../src/parts/EditorStates/EditorStates.ts'
+import { updateDiagnostics } from '../src/parts/UpdateDiagnostics/UpdateDiagnostics.ts'
 
 afterEach(() => {
+  EditorStates.dispose(1)
   remove(RpcId.ErrorWorker)
 })
 
-test('getEditorWithDiagnostics reports failures through the error worker', async () => {
+test('updateDiagnostics reports failures through the error worker', async () => {
   const error = new Error('diagnostics failed')
   const prettyError = {
     codeFrame: 'code frame',
@@ -23,16 +26,61 @@ test('getEditorWithDiagnostics reports failures through the error worker', async
     'Errors.print': async () => undefined,
   })
   const editor = {
+    diagnosticsEnabled: true,
     id: 1,
     languageId: 'typescript',
     lines: ['const value: string = 1'],
     uri: '/test.ts',
   }
+  EditorStates.set(1, editor as any, editor as any)
 
-  await expect(getEditorWithDiagnostics(editor)).resolves.toBe(editor)
+  await expect(updateDiagnostics(editor)).resolves.toBe(editor)
   expect(extensionHostRpc.invocations).toEqual([['ExtensionHostTextDocument.syncFull', '/test.ts', 1, 'typescript', 'const value: string = 1']])
   expect(errorWorkerRpc.invocations).toEqual([
     ['Errors.prepare', error],
     ['Errors.print', prettyError, 'Failed to update diagnostics: '],
   ])
+})
+
+test('updateDiagnostics skips disabled diagnostics', async () => {
+  const editor = {
+    diagnosticsEnabled: false,
+    id: 1,
+  }
+
+  await expect(updateDiagnostics(editor)).resolves.toBe(editor)
+})
+
+test('updateDiagnostics ignores results after the editor is closed', async () => {
+  const diagnosticsRequested = Promise.withResolvers<void>()
+  const diagnosticsResult = Promise.withResolvers<readonly any[]>()
+  using extensionHostRpc = ExtensionHost.registerMockRpc({
+    'ExtensionHostTextDocument.syncFull': async () => undefined,
+  })
+  ExtensionManagementWorker.set(
+    MockRpc.create({
+      commandMap: {},
+      invoke: async () => {
+        diagnosticsRequested.resolve()
+        return diagnosticsResult.promise
+      },
+    }),
+  )
+  const editor = {
+    diagnosticsEnabled: true,
+    id: 1,
+    languageId: 'typescript',
+    lines: ['const value = 1'],
+    uri: '/test.ts',
+  }
+  EditorStates.set(1, editor as any, editor as any)
+
+  const pendingUpdate = updateDiagnostics(editor)
+  await diagnosticsRequested.promise
+  EditorStates.dispose(1)
+  diagnosticsResult.resolve([{ columnIndex: 0, endColumnIndex: 1, rowIndex: 0, type: 'error' }])
+
+  await expect(pendingUpdate).resolves.toBe(editor)
+  expect(EditorStates.get(1)).toBeUndefined()
+  expect(extensionHostRpc.invocations).toEqual([['ExtensionHostTextDocument.syncFull', '/test.ts', 1, 'typescript', 'const value = 1']])
 })


### PR DESCRIPTION
Stops diagnostics providers from blocking initial editor creation. Diagnostics are now requested by the renderer after the editor is visible, and late results are ignored when the editor has closed.