### PR TITLE
feature: use dialog worker directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2831,9 +2831,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.20.0.tgz",
-      "integrity": "sha512-yDtT/MF73BsyMpx7DQSoJJLM3hJKTII9TuGEguwJmgULxqV3mND86npuvOhKGUjTvL0Fs8BEQYFjO4DCrjncwA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
+      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/editor-worker": {
@@ -3581,6 +3581,18 @@
         "@lvce-editor/ipc": "^16.4.0",
         "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
+      }
+    },
+    "node_modules/@lvce-editor/rpc-registry": {
+      "version": "9.42.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.42.0.tgz",
+      "integrity": "sha512-5/G0T87nC3aKRujuLJSpSsG0jPdXmrwDqRX3rHNmUWh7FaMPC0SoqBqenMTy2V+EHqnX0LRFyC6FO5LPwoPFgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/constants": "^5.22.0",
+        "@lvce-editor/rpc": "^6.4.0"
       }
     },
     "node_modules/@lvce-editor/search-process": {
@@ -16388,7 +16400,7 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-typescript": "^7.29.7",
-        "@lvce-editor/measure-memory": "3.4.0",
+        "@lvce-editor/measure-memory": "^3.4.0",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/node": "^24.2.1",
@@ -16537,7 +16549,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/test-with-playwright": "22.8.0"
+        "@lvce-editor/test-with-playwright": "^22.8.0"
       }
     },
     "packages/e2e/node_modules/@lvce-editor/test-with-playwright": {
@@ -16582,23 +16594,16 @@
       "devDependencies": {
         "@jest/globals": "^30.4.1",
         "@lvce-editor/assert": "^1.7.0",
-        "@lvce-editor/constants": "5.19.0",
-        "@lvce-editor/i18n": "2.4.0",
-        "@lvce-editor/rpc": "6.8.0",
-        "@lvce-editor/rpc-registry": "9.36.0",
+        "@lvce-editor/constants": "^5.19.0",
+        "@lvce-editor/i18n": "^2.4.0",
+        "@lvce-editor/rpc": "^6.8.0",
+        "@lvce-editor/rpc-registry": "^9.42.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
-        "@lvce-editor/virtual-dom-worker": "11.7.1",
+        "@lvce-editor/virtual-dom-worker": "^11.7.0",
         "jest": "^30.4.2",
-        "ts-jest": "29.4.11"
+        "ts-jest": "^29.4.11"
       }
-    },
-    "packages/editor-worker/node_modules/@lvce-editor/constants": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.19.0.tgz",
-      "integrity": "sha512-E+uV4TNbCXTjDqIyAoDC7HDBVlEXOLM1jCLXMmkT83m+TQr8tTehGY5nMfKSBBZI+DMe9NgUdA5NBJH43jXJOw==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/editor-worker/node_modules/@lvce-editor/i18n": {
       "version": "2.4.0",
@@ -16619,18 +16624,6 @@
         "@lvce-editor/ipc": "^16.3.0",
         "@lvce-editor/json-rpc": "^8.1.0",
         "@lvce-editor/verror": "^1.7.0"
-      }
-    },
-    "packages/editor-worker/node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.36.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.36.0.tgz",
-      "integrity": "sha512-fbV4xYg0jZn06TcicEOm0wM+kA23OXZk+NK3QZsjNCIBdl0Pv6+V0GiR1aAbU+wlMmbLuHkEpmtSXfoBKrbGBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.19.0",
-        "@lvce-editor/rpc": "^6.4.0"
       }
     },
     "packages/editor-worker/node_modules/@lvce-editor/virtual-dom-worker": {
@@ -16714,11 +16707,11 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@jest/globals": "30.3.0",
-        "@lvce-editor/rpc": "6.4.0",
-        "@types/node": "24.12.2",
-        "jest": "30.3.0",
-        "ts-jest": "29.4.9"
+        "@jest/globals": "^30.3.0",
+        "@lvce-editor/rpc": "^6.4.0",
+        "@types/node": "^24.2.1",
+        "jest": "^30.3.0",
+        "ts-jest": "^29.4.6"
       }
     },
     "packages/evaluation-worker/node_modules/@jest/console": {
@@ -17819,7 +17812,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "0.91.28"
+        "@lvce-editor/server": "^0.91.28"
       },
       "devDependencies": {
         "@types/node": "^25.9.3"

--- a/packages/editor-worker/package.json
+++ b/packages/editor-worker/package.json
@@ -57,7 +57,7 @@
     "@lvce-editor/constants": "^5.19.0",
     "@lvce-editor/i18n": "^2.4.0",
     "@lvce-editor/rpc": "^6.8.0",
-    "@lvce-editor/rpc-registry": "^9.36.0",
+    "@lvce-editor/rpc-registry": "^9.42.0",
     "@lvce-editor/verror": "^1.7.0",
     "@lvce-editor/viewlet-registry": "^5.5.0",
     "@lvce-editor/virtual-dom-worker": "^11.7.0",

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandSave/showSaveErrorDialog.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandSave/showSaveErrorDialog.ts
@@ -1,4 +1,4 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker } from '@lvce-editor/rpc-registry'
 
 const isPermissionDeniedError = (error: Error): boolean => {
   const errorCode = 'code' in error ? error.code : undefined
@@ -7,7 +7,7 @@ const isPermissionDeniedError = (error: Error): boolean => {
 
 export const showSaveErrorDialog = async (error: Error): Promise<void> => {
   if (isPermissionDeniedError(error)) {
-    await RendererWorker.invoke('ElectronDialog.showMessageBox', {
+    await DialogWorker.invoke('ElectronDialog.showMessageBox', {
       buttons: ['OK'],
       defaultId: 0,
       message: "You don't have permission to save changes to this file.",
@@ -16,7 +16,7 @@ export const showSaveErrorDialog = async (error: Error): Promise<void> => {
     })
     return
   }
-  await RendererWorker.invoke('ElectronDialog.showMessageBox', {
+  await DialogWorker.invoke('ElectronDialog.showMessageBox', {
     buttons: ['OK'],
     defaultId: 0,
     detail: error.message,

--- a/packages/editor-worker/src/parts/Listen/Listen.ts
+++ b/packages/editor-worker/src/parts/Listen/Listen.ts
@@ -1,3 +1,5 @@
+import { LazyTransferMessagePortRpcParent } from '@lvce-editor/rpc'
+import { DialogWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as CommandMap from '../CommandMap/CommandMap.ts'
 import { registerCommands } from '../EditorStates/EditorStates.ts'
 import { initializeErrorWorker } from '../InitializeErrorWorker/InitializeErrorWorker.ts'
@@ -17,4 +19,9 @@ export const listen = async () => {
     initializeTextMeasurementWorker(),
     initializeOpenerWorker(),
   ])
+  const dialogRpc = await LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send: RendererWorker.sendMessagePortToDialogWorker,
+  })
+  DialogWorker.set(dialogRpc)
 }

--- a/packages/editor-worker/test/Save.test.ts
+++ b/packages/editor-worker/test/Save.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, jest, test } from '@jest/globals'
 import { PlatformType } from '@lvce-editor/constants'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as EditorCommandSave from '../src/parts/EditorCommand/EditorCommandSave.ts'
 
 afterEach(() => {
@@ -10,12 +10,12 @@ afterEach(() => {
 test('save - shows a concise electron message box when permission is denied', async () => {
   jest.spyOn(console, 'error').mockImplementation(() => {})
   using mockRpc = RendererWorker.registerMockRpc({
-    'ElectronDialog.showMessageBox': async () => {
-      return 0
-    },
     'FileSystem.writeFile': async () => {
       throw new Error('EACCES: permission denied')
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ElectronDialog.showMessageBox': async () => 0,
   })
   const editor = {
     lines: ['hello world'],
@@ -27,8 +27,8 @@ test('save - shows a concise electron message box when permission is denied', as
   const result = await EditorCommandSave.save(editor)
 
   expect(result).toBe(editor)
-  expect(mockRpc.invocations).toEqual([
-    ['FileSystem.writeFile', 'file:///tmp/read-only.txt', 'hello world'],
+  expect(mockRpc.invocations).toEqual([['FileSystem.writeFile', 'file:///tmp/read-only.txt', 'hello world']])
+  expect(mockDialogRpc.invocations).toEqual([
     [
       'ElectronDialog.showMessageBox',
       {
@@ -45,12 +45,12 @@ test('save - shows a concise electron message box when permission is denied', as
 test('save - shows error details for other electron save errors', async () => {
   jest.spyOn(console, 'error').mockImplementation(() => {})
   using mockRpc = RendererWorker.registerMockRpc({
-    'ElectronDialog.showMessageBox': async () => {
-      return 0
-    },
     'FileSystem.writeFile': async () => {
       throw new Error('Disk is full')
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ElectronDialog.showMessageBox': async () => 0,
   })
   const editor = {
     lines: ['hello world'],
@@ -62,8 +62,8 @@ test('save - shows error details for other electron save errors', async () => {
   const result = await EditorCommandSave.save(editor)
 
   expect(result).toBe(editor)
-  expect(mockRpc.invocations).toEqual([
-    ['FileSystem.writeFile', 'file:///tmp/example.txt', 'hello world'],
+  expect(mockRpc.invocations).toEqual([['FileSystem.writeFile', 'file:///tmp/example.txt', 'hello world']])
+  expect(mockDialogRpc.invocations).toEqual([
     [
       'ElectronDialog.showMessageBox',
       {


### PR DESCRIPTION
## Summary

- connect to dialog-worker through a lazy transferred message port
- send confirm and message-box requests directly to dialog-worker
- update rpc-registry and the affected tests

## Testing

- focused dialog and Listen tests
- npm run type-check
- npm run lint