### PR TITLE
fix: render large text documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3789,6 +3789,16 @@
         "node": ">=22"
       }
     },
+    "node_modules/@lvce-editor/virtual-dom-worker": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.9.3.tgz",
+      "integrity": "sha512-urRtElom4Ha+0lAuYD+hBS5PzjncrFUHBnuRiDbIem3iHVvjDseDlxOp0VAv0VO4Ok78QlmtTNl2mo4dfcpWIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/constants": "^5.21.0"
+      }
+    },
     "node_modules/@lvce-editor/web-socket-server": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/web-socket-server/-/web-socket-server-2.1.0.tgz",
@@ -16614,7 +16624,7 @@
         "@lvce-editor/rpc-registry": "^9.42.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
-        "@lvce-editor/virtual-dom-worker": "^11.7.0",
+        "@lvce-editor/virtual-dom-worker": "^11.9.3",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.11"
       }
@@ -16638,16 +16648,6 @@
         "@lvce-editor/ipc": "^16.3.0",
         "@lvce-editor/json-rpc": "^8.1.0",
         "@lvce-editor/verror": "^1.7.0"
-      }
-    },
-    "packages/editor-worker/node_modules/@lvce-editor/virtual-dom-worker": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.7.1.tgz",
-      "integrity": "sha512-eOTz8FuoQsoP4XCuvGbT4yb0UuZpUfsvrqf0Df1I3aFpp1aOZH8NxEXzEcfKQ0rhKzIf96A5dQpmA77Xb/rFvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/constants": "^5.19.0"
       }
     },
     "packages/editor-worker/node_modules/ts-jest": {

--- a/packages/editor-worker/package.json
+++ b/packages/editor-worker/package.json
@@ -60,7 +60,7 @@
     "@lvce-editor/rpc-registry": "^9.42.0",
     "@lvce-editor/verror": "^1.7.0",
     "@lvce-editor/viewlet-registry": "^5.5.0",
-    "@lvce-editor/virtual-dom-worker": "^11.7.0",
+    "@lvce-editor/virtual-dom-worker": "^11.9.3",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.11"
   }


### PR DESCRIPTION
Update the editor worker to the virtual DOM release with stack-safe tree flattening.

This lets large heap snapshots and other large text documents render without overflowing the JavaScript call stack.