### PR TITLE
fix: use cached diagnostics in problems view

### DIFF
--- a/packages/editor-worker/src/parts/GetProblems/GetProblems.ts
+++ b/packages/editor-worker/src/parts/GetProblems/GetProblems.ts
@@ -1,22 +1,12 @@
 import type { Problem } from '../Problem/Problem.ts'
 import * as Editors from '../EditorStates/EditorStates.ts'
-import * as ExtensionHostDiagnostic from '../ExtensionHostDiagnostic/ExtensionHostDiagnostic.ts'
-
-const getDiagnostics = (editor: any): Promise<any> => {
-  return ExtensionHostDiagnostic.executeDiagnosticProvider(editor)
-}
 
 export const getProblems = async (): Promise<readonly Problem[]> => {
-  // TODO maybe combine querying diagnostics for problems view with diagnostics for editor
-  // or query the diagnostics for the problems view directtly from the extension host worker
   const keys = Editors.getKeys()
-  const editors = keys.map((key) => {
+  const diagnostics = keys.flatMap((key) => {
     const numericKey = Number(key)
     const editor = Editors.get(numericKey)
-    return editor
+    return editor.newState.diagnostics
   })
-  const newEditors = editors.map((editor) => editor.newState)
-  const diagnostics = await Promise.all(newEditors.map(getDiagnostics))
-  const flatDiagnostics = diagnostics.flat()
-  return flatDiagnostics
+  return diagnostics
 }

--- a/packages/editor-worker/test/GetProblems.test.ts
+++ b/packages/editor-worker/test/GetProblems.test.ts
@@ -1,38 +1,56 @@
-import { expect, test } from '@jest/globals'
+import { afterEach, expect, test } from '@jest/globals'
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import * as EditorStates from '../src/parts/EditorStates/EditorStates.ts'
 import { getProblems } from '../src/parts/GetProblems/GetProblems.ts'
 
-test('getProblems preserves fractional editor ids', async () => {
+afterEach(() => {
+  for (const key of EditorStates.getKeys()) {
+    EditorStates.dispose(Number(key))
+  }
+})
+
+test('getProblems returns cached diagnostics and preserves fractional editor ids', async () => {
   const editorId = 0.123456
+  const diagnostics = [
+    {
+      message: 'cached problem',
+      uri: '/test.js',
+    },
+  ]
   const editor = {
+    diagnostics,
     id: editorId,
     languageId: 'javascript',
     lines: ['const value = 1'],
     uid: editorId,
     uri: '/test.js',
   }
-  const diagnostics = [
-    {
-      message: 'test problem',
-      uri: editor.uri,
-    },
-  ]
   EditorStates.set(editorId, editor as any, editor as any)
   using mockRpc = ExtensionManagementWorker.registerMockRpc({
-    'Extensions.executeDiagnosticProvider': () => diagnostics,
+    'Extensions.executeDiagnosticProvider': () => [{ message: 'new problem' }],
   })
 
   await expect(getProblems()).resolves.toEqual(diagnostics)
-  expect(mockRpc.invocations).toEqual([
-    [
-      'Extensions.executeDiagnosticProvider',
-      {
-        documentId: editorId,
-        languageId: editor.languageId,
-        text: editor.lines[0],
-        uri: editor.uri,
-      },
-    ],
-  ])
+  expect(mockRpc.invocations).toEqual([])
+})
+
+test('getProblems ignores open editors without diagnostics', async () => {
+  const javascriptEditor = {
+    diagnostics: [{ message: 'javascript problem', uri: '/test.js' }],
+    id: 1,
+    languageId: 'javascript',
+    lines: ["let x = ''", 'x++'],
+    uri: '/test.js',
+  }
+  const settingsEditor = {
+    diagnostics: [],
+    id: 2,
+    languageId: 'json',
+    lines: ['{}'],
+    uri: 'app://settings.json',
+  }
+  EditorStates.set(1, javascriptEditor as any, javascriptEditor as any)
+  EditorStates.set(2, settingsEditor as any, settingsEditor as any)
+
+  await expect(getProblems()).resolves.toEqual(javascriptEditor.diagnostics)
 })


### PR DESCRIPTION
Use diagnostics already computed for open editors when populating Problems. This avoids rerunning providers, prevents unrelated editors without providers from breaking the view, and keeps editor squiggles and Problems in sync.