### PR TITLE
fix: update diagnostics after editor changes

### DIFF
--- a/packages/editor-worker/src/parts/EditorDiagnosticEffect/EditorDiagnosticEffect.ts
+++ b/packages/editor-worker/src/parts/EditorDiagnosticEffect/EditorDiagnosticEffect.ts
@@ -2,8 +2,8 @@ import * as UpdateDiagnostics from '../UpdateDiagnostics/UpdateDiagnostics.ts'
 
 export const editorDiagnosticEffect = {
   // TODO set effects delay / diagnostic delay
-  async apply(editor: any) {
-    await UpdateDiagnostics.updateDiagnostics(editor)
+  apply(editor: any) {
+    return UpdateDiagnostics.updateDiagnostics(editor)
   },
   // TODO avoid slow comparison
   isActive: (oldEditor: any, newEditor: any) => newEditor.diagnosticsEnabled && JSON.stringify(oldEditor.lines) !== JSON.stringify(newEditor.lines),

--- a/packages/editor-worker/src/parts/WrapCommands/WrapCommands.ts
+++ b/packages/editor-worker/src/parts/WrapCommands/WrapCommands.ts
@@ -1,3 +1,4 @@
+import { editorDiagnosticEffect } from '../EditorDiagnosticEffect/EditorDiagnosticEffect.ts'
 import * as Editors from '../EditorStates/EditorStates.ts'
 import * as UpdateDerivedState from '../UpdateDerivedState/UpdateDerivedState.ts'
 
@@ -24,7 +25,15 @@ export const wrapCommand =
       }
       const newEditorWithDerivedState = await UpdateDerivedState.updateDerivedState(state, newEditor)
       Editors.set(uid, state, newEditorWithDerivedState)
-      return newEditorWithDerivedState
+      if (!editorDiagnosticEffect.isActive(state, newEditorWithDerivedState)) {
+        return newEditorWithDerivedState
+      }
+      const newEditorWithDiagnostics = await editorDiagnosticEffect.apply(newEditorWithDerivedState)
+      if (!Editors.get(uid)) {
+        return newEditorWithDiagnostics
+      }
+      Editors.set(uid, state, newEditorWithDiagnostics)
+      return newEditorWithDiagnostics
     } finally {
       resolve()
       if (queues[uid] === next) {

--- a/packages/editor-worker/test/WrapCommands.test.ts
+++ b/packages/editor-worker/test/WrapCommands.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
 
 const updateDerivedStateMock = jest.fn()
+const editorDiagnosticEffectApplyMock: any = jest.fn()
+const editorDiagnosticEffectIsActiveMock: any = jest.fn()
 
 jest.unstable_mockModule('../src/parts/UpdateDerivedState/UpdateDerivedState.ts', () => ({
   updateDerivedState: updateDerivedStateMock,
+}))
+
+jest.unstable_mockModule('../src/parts/EditorDiagnosticEffect/EditorDiagnosticEffect.ts', () => ({
+  editorDiagnosticEffect: {
+    apply: editorDiagnosticEffectApplyMock,
+    isActive: editorDiagnosticEffectIsActiveMock,
+  },
 }))
 
 const EditorStates = await import('../src/parts/EditorStates/EditorStates.ts')
@@ -14,6 +23,10 @@ beforeEach(() => {
     text: '',
   }
   EditorStates.set(1, state as any, state as any)
+  editorDiagnosticEffectApplyMock.mockReset()
+  editorDiagnosticEffectApplyMock.mockImplementation(async (newState: any) => newState)
+  editorDiagnosticEffectIsActiveMock.mockReset()
+  editorDiagnosticEffectIsActiveMock.mockReturnValue(false)
   updateDerivedStateMock.mockReset()
   updateDerivedStateMock.mockImplementation(async (_oldState, newState) => {
     await Promise.resolve()
@@ -34,4 +47,30 @@ test('serializes concurrent commands for the same editor', async () => {
   await Promise.all([command(1, 'a'), command(1, 'b'), command(1, 'c')])
 
   expect((EditorStates.get(1).newState as any).text).toBe('abc')
+})
+
+test('applies diagnostics after a command changes the editor text', async () => {
+  const oldState = {
+    diagnosticsEnabled: true,
+    lines: [''],
+  }
+  const newState = {
+    diagnosticsEnabled: true,
+    lines: ['x'],
+  }
+  const stateWithDiagnostics = {
+    ...newState,
+    diagnostics: [{ message: 'error' }],
+  }
+  EditorStates.set(1, oldState as any, oldState as any)
+  editorDiagnosticEffectIsActiveMock.mockReturnValue(true)
+  editorDiagnosticEffectApplyMock.mockResolvedValue(stateWithDiagnostics)
+  const command = WrapCommands.wrapCommand(() => newState)
+
+  const result = await command(1)
+
+  expect(editorDiagnosticEffectIsActiveMock).toHaveBeenCalledWith(oldState, newState)
+  expect(editorDiagnosticEffectApplyMock).toHaveBeenCalledWith(newState)
+  expect(result).toBe(stateWithDiagnostics)
+  expect(EditorStates.get(1).newState).toBe(stateWithDiagnostics)
 })


### PR DESCRIPTION
Connects the existing diagnostic effect to serialized editor commands so diagnostics refresh whenever document lines change. Adds regression coverage for updating and caching diagnostics after an edit.