### PR TITLE
fix: ignore stale editors when querying problems

### DIFF
--- a/packages/editor-worker/src/parts/GetProblems/GetProblems.ts
+++ b/packages/editor-worker/src/parts/GetProblems/GetProblems.ts
@@ -6,6 +6,9 @@ export const getProblems = async (): Promise<readonly Problem[]> => {
   const diagnostics = keys.flatMap((key) => {
     const numericKey = Number(key)
     const editor = Editors.get(numericKey)
+    if (!editor?.newState) {
+      return []
+    }
     return editor.newState.diagnostics
   })
   return diagnostics

--- a/packages/editor-worker/test/GetProblems.test.ts
+++ b/packages/editor-worker/test/GetProblems.test.ts
@@ -54,3 +54,20 @@ test('getProblems ignores open editors without diagnostics', async () => {
 
   await expect(getProblems()).resolves.toEqual(javascriptEditor.diagnostics)
 })
+
+test('getProblems ignores editor entries without a readable state', async () => {
+  const editor = {
+    diagnostics: [{ message: 'stale problem', uri: '/stale.js' }],
+    id: undefined,
+    languageId: 'javascript',
+    lines: [''],
+    uri: '/stale.js',
+  }
+  EditorStates.set(undefined as any, editor as any, editor as any)
+
+  try {
+    await expect(getProblems()).resolves.toEqual([])
+  } finally {
+    EditorStates.dispose(undefined as any)
+  }
+})


### PR DESCRIPTION
Ignore editor registry entries that no longer resolve to a current state while collecting cached diagnostics. This prevents the Problems view from surfacing a TypeError when closing the active editor selects its neighbor.