### PR TITLE
feature: add standalone editor creation

### DIFF
--- a/packages/build/src/config.ts
+++ b/packages/build/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 881_000
+export const threshold = 883_000
 
 export const workerPath = join(root, '.tmp/dist/dist/editorWorkerMain.js')
 

--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -4,6 +4,7 @@ import * as CodeGeneratorAccept from '../CodeGeneratorAccept/CodeGeneratorAccept
 import * as ColorPicker from '../ColorPicker/ColorPicker.ts'
 import { createEditor2 } from '../CreateEditor2/CreateEditor2.ts'
 import * as CreateEditor from '../CreateEditor/CreateEditor.ts'
+import { createStandaloneEditor } from '../CreateStandaloneEditor/CreateStandaloneEditor.ts'
 import { diff2 } from '../Diff2/Diff2.ts'
 import * as DisposeEditor from '../DisposeEditor/DisposeEditor.ts'
 import * as AddCursorAbove from '../EditorCommand/EditorCommandAddCursorAbove.ts'
@@ -212,6 +213,7 @@ export const commandMap = {
   'Editor.copyLineUp': wrapCommand(CopyLineUp.copyLineUp),
   'Editor.create': CreateEditor.createEditor,
   'Editor.create2': createEditor2,
+  'Editor.createStandalone': createStandaloneEditor,
   'Editor.cursorCharacterLeft': wrapCommand(CursorCharacterLeft.cursorCharacterLeft),
   'Editor.cursorCharacterRight': wrapCommand(CursorCharacterRight.cursorCharacterRight),
   'Editor.cursorDocumentEnd': wrapCommand(CursorDocumentEnd.cursorDocumentEnd),

--- a/packages/editor-worker/src/parts/CreateStandaloneEditor/CreateStandaloneEditor.ts
+++ b/packages/editor-worker/src/parts/CreateStandaloneEditor/CreateStandaloneEditor.ts
@@ -1,0 +1,96 @@
+import { WhenExpression } from '@lvce-editor/constants'
+import { createEditor2 } from '../CreateEditor2/CreateEditor2.ts'
+import * as Editor from '../Editor/Editor.ts'
+import * as EditorSelection from '../EditorSelection/EditorSelection.ts'
+import * as EditorStates from '../EditorStates/EditorStates.ts'
+import * as EditorText from '../EditorText/EditorText.ts'
+import * as Tokenizer from '../Tokenizer/Tokenizer.ts'
+import * as TokenizerMap from '../TokenizerMap/TokenizerMap.ts'
+
+export interface StandaloneEditorOptions {
+  readonly assetDir: string
+  readonly charWidth: number
+  readonly content: string
+  readonly fontFamily: string
+  readonly fontSize: number
+  readonly fontWeight: number
+  readonly height: number
+  readonly id: number
+  readonly languageId: string
+  readonly letterSpacing: number
+  readonly lineNumbers: boolean
+  readonly platform: number
+  readonly rowHeight: number
+  readonly tabSize: number
+  readonly tokenizePath: string
+  readonly uri: string
+  readonly width: number
+  readonly x: number
+  readonly y: number
+}
+
+export const createStandaloneEditor = async ({
+  assetDir,
+  charWidth,
+  content,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  height,
+  id,
+  languageId,
+  letterSpacing,
+  lineNumbers,
+  platform,
+  rowHeight,
+  tabSize,
+  tokenizePath,
+  uri,
+  width,
+  x,
+  y,
+}: StandaloneEditorOptions): Promise<void> => {
+  createEditor2(id, uri, x, y, width, height, platform, assetDir)
+  const createdEditor = EditorStates.get(id).newState
+
+  await Tokenizer.loadTokenizer(languageId, tokenizePath)
+  const tokenizerId = createdEditor.tokenizerId + 1
+  TokenizerMap.set(tokenizerId, Tokenizer.getTokenizer(languageId))
+
+  const configuredEditor = {
+    ...createdEditor,
+    charWidth,
+    columnWidth: charWidth,
+    completionsOnType: false,
+    focus: WhenExpression.FocusEditorText,
+    focused: true,
+    fontFamily,
+    fontSize,
+    fontWeight,
+    initial: false,
+    isMonospaceFont: true,
+    itemHeight: rowHeight,
+    languageId,
+    letterSpacing,
+    lineNumbers,
+    rowHeight,
+    selections: new Uint32Array([0, 0, 0, 0]),
+    tabSize,
+    tokenizerId,
+  }
+  const boundedEditor = Editor.setBounds(configuredEditor, x, y, width, height, charWidth)
+  const editorWithText = Editor.setText(boundedEditor, content)
+  const { differences, textInfos } = await EditorText.getVisible(editorWithText, true)
+  const editorWithVisibleText = {
+    ...editorWithText,
+    differences,
+    textInfos,
+  }
+  const { cursorInfos, selectionInfos } = await EditorSelection.getVisible(editorWithVisibleText)
+  const finalEditor = {
+    ...editorWithVisibleText,
+    cursorInfos,
+    selectionInfos,
+  }
+  EditorStates.set(id, createdEditor, finalEditor)
+}

--- a/packages/editor-worker/test/CreateStandaloneEditor.test.ts
+++ b/packages/editor-worker/test/CreateStandaloneEditor.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@jest/globals'
+import { createStandaloneEditor } from '../src/parts/CreateStandaloneEditor/CreateStandaloneEditor.ts'
+import { diff2 } from '../src/parts/Diff2/Diff2.ts'
+import * as EditorStates from '../src/parts/EditorStates/EditorStates.ts'
+import { render2 } from '../src/parts/Render2/Render2.ts'
+
+test('creates a functional standalone editor without workbench services', async () => {
+  const id = 901
+  await createStandaloneEditor({
+    assetDir: '/assets',
+    charWidth: 9,
+    content: '<h1>Hello</h1>',
+    fontFamily: 'monospace',
+    fontSize: 15,
+    fontWeight: 400,
+    height: 600,
+    id,
+    languageId: 'html',
+    letterSpacing: 0,
+    lineNumbers: false,
+    platform: 2,
+    rowHeight: 20,
+    tabSize: 2,
+    tokenizePath: '',
+    uri: 'file:///benchmark.html',
+    width: 800,
+    x: 0,
+    y: 0,
+  })
+
+  const editor = EditorStates.get(id).newState
+  expect(editor.lines).toEqual(['<h1>Hello</h1>'])
+  expect(editor.selections).toEqual(new Uint32Array([0, 0, 0, 0]))
+  expect(editor.focused).toBe(true)
+  expect(editor.initial).toBe(false)
+  expect(editor.languageId).toBe('html')
+
+  const commands = render2(id, diff2(id))
+  expect(commands.some((command) => command[0] === 'Viewlet.setPatches')).toBe(true)
+})


### PR DESCRIPTION
## Summary
- add a narrow `Editor.createStandalone` worker command
- initialize text, selection, bounds, font, and tokenizer state without workbench services
- cover standalone creation and initial rendering
- adjust the worker memory threshold for the new command