### PR TITLE
fix: use object based open uri rpc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2831,9 +2831,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
-      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.24.0.tgz",
+      "integrity": "sha512-PfoXM8k5Na8kGwERyHRyCZfSq4AGYcjbvDJv+Y4zdCRsT9qvr5QNM7HCDkH4LU1RdM2nrmO8I1ufzNy8NtfZ6w==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/editor-worker": {
@@ -3598,14 +3598,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.42.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.42.0.tgz",
-      "integrity": "sha512-5/G0T87nC3aKRujuLJSpSsG0jPdXmrwDqRX3rHNmUWh7FaMPC0SoqBqenMTy2V+EHqnX0LRFyC6FO5LPwoPFgQ==",
+      "version": "9.45.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.45.0.tgz",
+      "integrity": "sha512-ypYUPS9mBnTJDKfJ9P5ECdrsqHTEhjp6ikWLBLaDXnsNWbgmEmntTiEtlAQegwsPlBUblm69HGzESR4D5ot85g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.22.0",
+        "@lvce-editor/constants": "^5.24.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
@@ -16621,7 +16621,7 @@
         "@lvce-editor/constants": "^5.19.0",
         "@lvce-editor/i18n": "^2.4.0",
         "@lvce-editor/rpc": "^6.8.0",
-        "@lvce-editor/rpc-registry": "^9.42.0",
+        "@lvce-editor/rpc-registry": "^9.45.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
         "@lvce-editor/virtual-dom-worker": "^11.9.3",

--- a/packages/editor-worker/package.json
+++ b/packages/editor-worker/package.json
@@ -57,7 +57,7 @@
     "@lvce-editor/constants": "^5.19.0",
     "@lvce-editor/i18n": "^2.4.0",
     "@lvce-editor/rpc": "^6.8.0",
-    "@lvce-editor/rpc-registry": "^9.42.0",
+    "@lvce-editor/rpc-registry": "^9.45.0",
     "@lvce-editor/verror": "^1.7.0",
     "@lvce-editor/viewlet-registry": "^5.5.0",
     "@lvce-editor/virtual-dom-worker": "^11.9.3",


### PR DESCRIPTION
## Summary

- update rpc-registry to the object-based Main.openUri contract
- include the corrected URI, focus, and selection options when navigating to definitions

## Validation

- npm test (578 passed, 53 skipped)
- npm run type-check
- npm run lint
- npm run build
- git diff --check