### PR TITLE
feature: show editor signature help

### DIFF
--- a/packages/build/src/config.ts
+++ b/packages/build/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 884_000
+export const threshold = 887_000
 
 export const workerPath = join(root, '.tmp/dist/dist/editorWorkerMain.js')
 

--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -125,6 +125,7 @@ import * as SetSelections from '../EditorCommand/EditorCommandSetSelections.ts'
 import * as SetText from '../EditorCommand/EditorCommandSetText.ts'
 import * as EditorCommandShowHover2 from '../EditorCommand/EditorCommandShowHover2.ts'
 import * as EditorShowHover from '../EditorCommand/EditorCommandShowHover.ts'
+import * as EditorCommandShowSignatureHelp from '../EditorCommand/EditorCommandShowSignatureHelp.ts'
 import * as EditorCommandShowSourceActions3 from '../EditorCommand/EditorCommandShowSourceActions3.ts'
 import * as SortLinesAscending from '../EditorCommand/EditorCommandSortLinesAscending.ts'
 import * as EditorTabCompletion from '../EditorCommand/EditorCommandTabCompletion.ts'
@@ -367,6 +368,7 @@ export const commandMap = {
   'Editor.setText': wrapCommand(SetText.setText),
   'Editor.showHover': EditorShowHover.showHover,
   'Editor.showHover2': wrapCommand(EditorCommandShowHover2.showHover2),
+  'Editor.showSignatureHelp': wrapCommand(EditorCommandShowSignatureHelp.showSignatureHelp),
   'Editor.showSourceActions': wrapCommand(EditorCommandShowSourceActions3.showSourceActions),
   'Editor.showSourceActions2': wrapCommand(EditorCommandShowSourceActions3.showSourceActions),
   'Editor.showSourceActions3': wrapCommand(EditorCommandShowSourceActions3.showSourceActions),

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandShowSignatureHelp.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandShowSignatureHelp.ts
@@ -1,0 +1,28 @@
+import { WidgetId } from '@lvce-editor/constants'
+import type { HoverState } from '../HoverState/HoverState.ts'
+import * as AddWidgetToEditor from '../AddWidgetToEditor/AddWidgetToEditor.ts'
+import * as FocusKey from '../FocusKey/FocusKey.ts'
+import * as HasWidget from '../HasWidget/HasWidget.ts'
+import * as HoverWidgetFactory from '../HoverWidgetFactory/HoverWidgetFactory.ts'
+import * as LoadSignatureHelpContent from '../LoadSignatureHelpContent/LoadSignatureHelpContent.ts'
+import * as RemoveEditorWidget from '../RemoveEditorWidget/RemoveEditorWidget.ts'
+
+export const showSignatureHelp = async (editor: any): Promise<any> => {
+  const { widgets = [] } = editor
+  const editorWithoutHover = HasWidget.hasWidget(widgets, WidgetId.Hover)
+    ? {
+        ...editor,
+        widgets: RemoveEditorWidget.removeEditorWidget(widgets, WidgetId.Hover),
+      }
+    : editor
+  const newStateGenerator = async (state: HoverState): Promise<HoverState | undefined> => {
+    return LoadSignatureHelpContent.loadSignatureHelpContent(state)
+  }
+  return AddWidgetToEditor.addWidgetToEditor(
+    WidgetId.Hover,
+    FocusKey.FocusEditorHover,
+    editorWithoutHover,
+    HoverWidgetFactory.create,
+    newStateGenerator,
+  )
+}

--- a/packages/editor-worker/src/parts/ExtensionHostSignatureHelp/ExtensionHostSignatureHelp.ts
+++ b/packages/editor-worker/src/parts/ExtensionHostSignatureHelp/ExtensionHostSignatureHelp.ts
@@ -1,0 +1,20 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import type { SignatureHelpResult } from '../SignatureHelpResult/SignatureHelpResult.ts'
+import * as Assert from '../Assert/Assert.ts'
+import * as TextDocument from '../TextDocument/TextDocument.ts'
+
+const getTextDocument = (editor: any) => {
+  return {
+    documentId: editor.id || editor.uid,
+    languageId: editor.languageId,
+    text: TextDocument.getText(editor),
+    uri: editor.uri,
+  }
+}
+
+export const executeSignatureHelpProvider = async (editor: any, offset: number): Promise<SignatureHelpResult | undefined> => {
+  Assert.object(editor)
+  Assert.number(offset)
+  const textDocument = getTextDocument(editor)
+  return ExtensionManagementWorker.invoke('Extensions.executeSignatureHelpProvider', textDocument, offset)
+}

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -495,8 +495,13 @@ export const getKeyBindings = () => {
     },
     {
       command: 'Editor.selectionGrow',
-      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.Space,
+      key: KeyModifier.Alt | KeyModifier.Shift | KeyCode.RightArrow,
       when: WhenExpression.FocusEditor,
+    },
+    {
+      command: 'Editor.showSignatureHelp',
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.Space,
+      when: WhenExpression.FocusEditorText,
     },
   ]
 }

--- a/packages/editor-worker/src/parts/GetSignatureHelpContent/GetSignatureHelpContent.ts
+++ b/packages/editor-worker/src/parts/GetSignatureHelpContent/GetSignatureHelpContent.ts
@@ -1,0 +1,38 @@
+import type { SignatureHelpParameter, SignatureHelpResult, SignatureHelpSignature } from '../SignatureHelpResult/SignatureHelpResult.ts'
+
+export interface SignatureHelpContent {
+  readonly displayString: string
+  readonly documentation: string
+}
+
+const clampIndex = (index: number, length: number): number => {
+  return Math.max(0, Math.min(index, length - 1))
+}
+
+const getDocumentation = (signature: SignatureHelpSignature, parameter: SignatureHelpParameter | undefined, activeParameter: number): string => {
+  const documentation: string[] = []
+  if (parameter) {
+    documentation.push(`Parameter ${activeParameter + 1} of ${signature.parameters.length}: ${parameter.label}`)
+    if (parameter.documentation) {
+      documentation.push(parameter.documentation)
+    }
+  }
+  if (signature.documentation) {
+    documentation.push(signature.documentation)
+  }
+  return documentation.join('\n')
+}
+
+export const getSignatureHelpContent = (signatureHelp: SignatureHelpResult): SignatureHelpContent | undefined => {
+  if (signatureHelp.signatures.length === 0) {
+    return undefined
+  }
+  const activeSignature = clampIndex(signatureHelp.activeSignature, signatureHelp.signatures.length)
+  const signature = signatureHelp.signatures[activeSignature]
+  const activeParameter = clampIndex(signatureHelp.activeParameter, signature.parameters.length)
+  const parameter = signature.parameters[activeParameter]
+  return {
+    displayString: signature.label,
+    documentation: getDocumentation(signature, parameter, activeParameter),
+  }
+}

--- a/packages/editor-worker/src/parts/GetSignatureHelpInfo/GetSignatureHelpInfo.ts
+++ b/packages/editor-worker/src/parts/GetSignatureHelpInfo/GetSignatureHelpInfo.ts
@@ -1,0 +1,54 @@
+import * as Assert from '../Assert/Assert.ts'
+import * as EditorPosition from '../EditorCommand/EditorCommandPosition.ts'
+import * as Editors from '../EditorStates/EditorStates.ts'
+import * as GetSignatureHelpContent from '../GetSignatureHelpContent/GetSignatureHelpContent.ts'
+import * as MeasureTextHeight from '../MeasureTextHeight/MeasureTextHeight.ts'
+import * as SignatureHelp from '../SignatureHelp/SignatureHelp.ts'
+import * as TextDocument from '../TextDocument/TextDocument.ts'
+import * as TokenizeCodeBlock from '../TokenizeCodeBlock/TokenizeCodeBlock.ts'
+
+const documentationFontSize = 15
+const documentationFontFamily = 'Fira Code'
+const documentationLineHeight = '1.33333'
+const borderLeft = 1
+const borderRight = 1
+const paddingLeft = 8
+const paddingRight = 8
+const fullWidth = 600
+const documentationWidth = fullWidth - paddingLeft - paddingRight - borderLeft - borderRight
+
+export const getSignatureHelpInfo = async (editorUid: number) => {
+  Assert.number(editorUid)
+  const instance = Editors.get(editorUid)
+  const editor = instance.newState
+  const { selections } = editor
+  const rowIndex = selections[0]
+  const columnIndex = selections[1]
+  const offset = TextDocument.offsetAt(editor, rowIndex, columnIndex)
+  const signatureHelp = await SignatureHelp.getSignatureHelp(editor, offset)
+  if (!signatureHelp) {
+    return undefined
+  }
+  const content = GetSignatureHelpContent.getSignatureHelpContent(signatureHelp)
+  if (!content) {
+    return undefined
+  }
+  const { displayString, documentation } = content
+  const lineInfos = await TokenizeCodeBlock.tokenizeCodeBlock(displayString, editor.languageId || 'typescript', '')
+  const documentationHeight = await MeasureTextHeight.measureTextBlockHeight(
+    documentation,
+    documentationFontFamily,
+    documentationFontSize,
+    documentationLineHeight,
+    documentationWidth,
+  )
+  const x = EditorPosition.x(editor, rowIndex, columnIndex)
+  const y = editor.height - EditorPosition.y(editor, rowIndex) + editor.y + 40
+  return {
+    documentation,
+    documentationHeight,
+    lineInfos,
+    x,
+    y,
+  }
+}

--- a/packages/editor-worker/src/parts/LoadSignatureHelpContent/LoadSignatureHelpContent.ts
+++ b/packages/editor-worker/src/parts/LoadSignatureHelpContent/LoadSignatureHelpContent.ts
@@ -1,0 +1,20 @@
+import type { HoverState } from '../HoverState/HoverState.ts'
+import * as GetSignatureHelpInfo from '../GetSignatureHelpInfo/GetSignatureHelpInfo.ts'
+
+export const loadSignatureHelpContent = async (state: HoverState): Promise<HoverState | undefined> => {
+  const { editorUid } = state
+  const signatureHelpInfo = await GetSignatureHelpInfo.getSignatureHelpInfo(editorUid)
+  if (!signatureHelpInfo) {
+    return undefined
+  }
+  const { documentation, lineInfos, x, y } = signatureHelpInfo
+  return {
+    ...state,
+    diagnostics: [],
+    documentation,
+    lineInfos,
+    width: 600,
+    x,
+    y,
+  }
+}

--- a/packages/editor-worker/src/parts/SignatureHelp/SignatureHelp.ts
+++ b/packages/editor-worker/src/parts/SignatureHelp/SignatureHelp.ts
@@ -1,0 +1,6 @@
+import type { SignatureHelpResult } from '../SignatureHelpResult/SignatureHelpResult.ts'
+import * as ExtensionHostSignatureHelp from '../ExtensionHostSignatureHelp/ExtensionHostSignatureHelp.ts'
+
+export const getSignatureHelp = async (editor: any, offset: number): Promise<SignatureHelpResult | undefined> => {
+  return ExtensionHostSignatureHelp.executeSignatureHelpProvider(editor, offset)
+}

--- a/packages/editor-worker/src/parts/SignatureHelpResult/SignatureHelpResult.ts
+++ b/packages/editor-worker/src/parts/SignatureHelpResult/SignatureHelpResult.ts
@@ -1,0 +1,16 @@
+export interface SignatureHelpParameter {
+  readonly documentation?: string
+  readonly label: string
+}
+
+export interface SignatureHelpSignature {
+  readonly documentation?: string
+  readonly label: string
+  readonly parameters: readonly SignatureHelpParameter[]
+}
+
+export interface SignatureHelpResult {
+  readonly activeParameter: number
+  readonly activeSignature: number
+  readonly signatures: readonly SignatureHelpSignature[]
+}

--- a/packages/editor-worker/test/ExtensionHostSignatureHelp.test.ts
+++ b/packages/editor-worker/test/ExtensionHostSignatureHelp.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@jest/globals'
+import { MockRpc } from '@lvce-editor/rpc'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import * as ExtensionHostSignatureHelp from '../src/parts/ExtensionHostSignatureHelp/ExtensionHostSignatureHelp.ts'
+
+test('executeSignatureHelpProvider invokes the isolated provider with the current document', async () => {
+  const invocations: unknown[] = []
+  const result = {
+    activeParameter: 0,
+    activeSignature: 0,
+    signatures: [{ label: 'fn(value: string): void', parameters: [{ label: 'value: string' }] }],
+  }
+  ExtensionManagementWorker.set(
+    MockRpc.create({
+      commandMap: {},
+      invoke: async (method: string, ...args: readonly unknown[]) => {
+        invocations.push([method, ...args])
+        return result
+      },
+    }),
+  )
+  const editor = {
+    id: 1,
+    languageId: 'typescript',
+    lines: ['fn('],
+    uid: 1,
+    uri: '/test.ts',
+  }
+
+  await expect(ExtensionHostSignatureHelp.executeSignatureHelpProvider(editor, 3)).resolves.toBe(result)
+  expect(invocations).toEqual([
+    [
+      'Extensions.executeSignatureHelpProvider',
+      {
+        documentId: 1,
+        languageId: 'typescript',
+        text: 'fn(',
+        uri: '/test.ts',
+      },
+      3,
+    ],
+  ])
+})

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -92,6 +92,22 @@ test('Shift+F12 finds all references', () => {
   })
 })
 
+test('Ctrl/Cmd+Shift+Space shows signature help', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.showSignatureHelp',
+    key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.Space,
+    when: WhenExpression.FocusEditorText,
+  })
+})
+
+test('Shift+Alt+Right grows the selection', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.selectionGrow',
+    key: KeyModifier.Shift | KeyModifier.Alt | KeyCode.RightArrow,
+    when: WhenExpression.FocusEditor,
+  })
+})
+
 test('PageDown advances the editor viewport', () => {
   expect(GetKeyBindings.getKeyBindings()).toContainEqual({
     command: 'Editor.cursorPageDown',

--- a/packages/editor-worker/test/GetSignatureHelpContent.test.ts
+++ b/packages/editor-worker/test/GetSignatureHelpContent.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@jest/globals'
+import * as GetSignatureHelpContent from '../src/parts/GetSignatureHelpContent/GetSignatureHelpContent.ts'
+
+test('returns the active signature and parameter documentation', () => {
+  expect(
+    GetSignatureHelpContent.getSignatureHelpContent({
+      activeParameter: 1,
+      activeSignature: 0,
+      signatures: [
+        {
+          documentation: 'Calls foo.',
+          label: 'foo(first: string, second: number): void',
+          parameters: [
+            {
+              documentation: 'First value.',
+              label: 'first: string',
+            },
+            {
+              documentation: 'Second value.',
+              label: 'second: number',
+            },
+          ],
+        },
+      ],
+    }),
+  ).toEqual({
+    displayString: 'foo(first: string, second: number): void',
+    documentation: 'Parameter 2 of 2: second: number\nSecond value.\nCalls foo.',
+  })
+})
+
+test('clamps invalid signature and parameter indexes', () => {
+  expect(
+    GetSignatureHelpContent.getSignatureHelpContent({
+      activeParameter: 10,
+      activeSignature: 10,
+      signatures: [
+        {
+          label: 'first(): void',
+          parameters: [],
+        },
+        {
+          label: 'second(value: string): void',
+          parameters: [{ label: 'value: string' }],
+        },
+      ],
+    }),
+  ).toEqual({
+    displayString: 'second(value: string): void',
+    documentation: 'Parameter 1 of 1: value: string',
+  })
+})
+
+test('returns undefined when there are no signatures', () => {
+  expect(
+    GetSignatureHelpContent.getSignatureHelpContent({
+      activeParameter: 0,
+      activeSignature: 0,
+      signatures: [],
+    }),
+  ).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- add Ctrl/Cmd+Shift+Space signature help while preserving selection grow on Shift+Alt+Right
- request isolated signature help for the active text document and cursor offset
- render the selected signature and active-parameter documentation in the editor popup

## Testing
- npm test -w @lvce-editor/editor-worker -- --runInBand (584 passed, 53 skipped)
- npm run type-check
- npm run lint
- npm run build