### PR TITLE
fix: size and position signature help

### DIFF
--- a/packages/editor-worker/src/parts/GetSignatureHelpInfo/GetSignatureHelpInfo.ts
+++ b/packages/editor-worker/src/parts/GetSignatureHelpInfo/GetSignatureHelpInfo.ts
@@ -1,7 +1,7 @@
 import * as Assert from '../Assert/Assert.ts'
-import * as EditorPosition from '../EditorCommand/EditorCommandPosition.ts'
 import * as Editors from '../EditorStates/EditorStates.ts'
 import * as GetSignatureHelpContent from '../GetSignatureHelpContent/GetSignatureHelpContent.ts'
+import * as GetSignatureHelpWidgetBounds from '../GetSignatureHelpWidgetBounds/GetSignatureHelpWidgetBounds.ts'
 import * as MeasureTextHeight from '../MeasureTextHeight/MeasureTextHeight.ts'
 import * as SignatureHelp from '../SignatureHelp/SignatureHelp.ts'
 import * as TextDocument from '../TextDocument/TextDocument.ts'
@@ -14,9 +14,6 @@ const borderLeft = 1
 const borderRight = 1
 const paddingLeft = 8
 const paddingRight = 8
-const fullWidth = 600
-const documentationWidth = fullWidth - paddingLeft - paddingRight - borderLeft - borderRight
-
 export const getSignatureHelpInfo = async (editorUid: number) => {
   Assert.number(editorUid)
   const instance = Editors.get(editorUid)
@@ -35,6 +32,8 @@ export const getSignatureHelpInfo = async (editorUid: number) => {
   }
   const { displayString, documentation } = content
   const lineInfos = await TokenizeCodeBlock.tokenizeCodeBlock(displayString, editor.languageId || 'typescript', '')
+  const fullWidth = Math.min(600, editor.width)
+  const documentationWidth = fullWidth - paddingLeft - paddingRight - borderLeft - borderRight
   const documentationHeight = await MeasureTextHeight.measureTextBlockHeight(
     documentation,
     documentationFontFamily,
@@ -42,13 +41,17 @@ export const getSignatureHelpInfo = async (editorUid: number) => {
     documentationLineHeight,
     documentationWidth,
   )
-  const x = EditorPosition.x(editor, rowIndex, columnIndex)
-  const y = editor.height - EditorPosition.y(editor, rowIndex) + editor.y + 40
-  return {
-    documentation,
+  const bounds = GetSignatureHelpWidgetBounds.getSignatureHelpWidgetBounds(
+    editor,
+    rowIndex,
+    columnIndex,
+    lineInfos.length,
     documentationHeight,
+    Boolean(documentation),
+  )
+  return {
+    ...bounds,
+    documentation,
     lineInfos,
-    x,
-    y,
   }
 }

--- a/packages/editor-worker/src/parts/GetSignatureHelpWidgetBounds/GetSignatureHelpWidgetBounds.ts
+++ b/packages/editor-worker/src/parts/GetSignatureHelpWidgetBounds/GetSignatureHelpWidgetBounds.ts
@@ -1,0 +1,41 @@
+import * as Clamp from '../Clamp/Clamp.ts'
+import * as EditorPosition from '../EditorCommand/EditorCommandPosition.ts'
+
+const borderHeight = 2
+const documentationPaddingHeight = 8
+const displayStringLineHeight = 20
+const displayStringPaddingHeight = 8
+const preferredWidth = 600
+
+const getHeight = (lineCount: number, documentationHeight: number, hasDocumentation: boolean): number => {
+  const displayStringHeight = lineCount * displayStringLineHeight + displayStringPaddingHeight
+  const fullDocumentationHeight = hasDocumentation ? documentationHeight + documentationPaddingHeight : 0
+  return borderHeight + displayStringHeight + fullDocumentationHeight
+}
+
+export const getSignatureHelpWidgetBounds = (
+  editor: any,
+  rowIndex: number,
+  columnIndex: number,
+  lineCount: number,
+  documentationHeight: number,
+  hasDocumentation: boolean,
+) => {
+  const width = Math.min(preferredWidth, editor.width)
+  const height = Math.min(getHeight(lineCount, documentationHeight, hasDocumentation), editor.height)
+  const cursorX = EditorPosition.x(editor, rowIndex, columnIndex)
+  const cursorY = EditorPosition.y(editor, rowIndex)
+  const editorRight = editor.x + editor.width
+  const editorBottom = editor.y + editor.height
+  const x = Clamp.clamp(cursorX, editor.x, editorRight - width)
+  const yBelow = cursorY
+  const yAbove = cursorY - editor.rowHeight - height
+  const preferredY = yBelow + height <= editorBottom ? yBelow : yAbove
+  const y = Clamp.clamp(preferredY, editor.y, editorBottom - height)
+  return {
+    height,
+    width,
+    x,
+    y,
+  }
+}

--- a/packages/editor-worker/src/parts/LoadSignatureHelpContent/LoadSignatureHelpContent.ts
+++ b/packages/editor-worker/src/parts/LoadSignatureHelpContent/LoadSignatureHelpContent.ts
@@ -7,13 +7,14 @@ export const loadSignatureHelpContent = async (state: HoverState): Promise<Hover
   if (!signatureHelpInfo) {
     return undefined
   }
-  const { documentation, lineInfos, x, y } = signatureHelpInfo
+  const { documentation, height, lineInfos, width, x, y } = signatureHelpInfo
   return {
     ...state,
     diagnostics: [],
     documentation,
+    height,
     lineInfos,
-    width: 600,
+    width,
     x,
     y,
   }

--- a/packages/editor-worker/test/GetSignatureHelpWidgetBounds.test.ts
+++ b/packages/editor-worker/test/GetSignatureHelpWidgetBounds.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@jest/globals'
+import * as GetSignatureHelpWidgetBounds from '../src/parts/GetSignatureHelpWidgetBounds/GetSignatureHelpWidgetBounds.ts'
+
+const editor = {
+  columnWidth: 9,
+  height: 500,
+  rowHeight: 20,
+  width: 1024,
+  x: 0,
+  y: 55,
+}
+
+test('positions signature help below the cursor when it fits', () => {
+  expect(GetSignatureHelpWidgetBounds.getSignatureHelpWidgetBounds(editor, 4, 20, 1, 60, true)).toEqual({
+    height: 98,
+    width: 600,
+    x: 180,
+    y: 155,
+  })
+})
+
+test('positions signature help above the cursor near the bottom of the editor', () => {
+  expect(GetSignatureHelpWidgetBounds.getSignatureHelpWidgetBounds(editor, 23, 20, 1, 60, true)).toEqual({
+    height: 98,
+    width: 600,
+    x: 180,
+    y: 417,
+  })
+})
+
+test('keeps signature help within a narrow editor', () => {
+  expect(
+    GetSignatureHelpWidgetBounds.getSignatureHelpWidgetBounds(
+      {
+        ...editor,
+        width: 400,
+      },
+      4,
+      50,
+      1,
+      0,
+      false,
+    ),
+  ).toEqual({
+    height: 30,
+    width: 400,
+    x: 0,
+    y: 155,
+  })
+})
+
+test('keeps tall signature help within the editor', () => {
+  expect(
+    GetSignatureHelpWidgetBounds.getSignatureHelpWidgetBounds(
+      {
+        ...editor,
+        height: 100,
+      },
+      4,
+      20,
+      1,
+      300,
+      true,
+    ),
+  ).toEqual({
+    height: 100,
+    width: 600,
+    x: 180,
+    y: 55,
+  })
+})


### PR DESCRIPTION
## Summary
- size signature-help popups from their signature and documentation content
- position them next to the active call while keeping them inside the editor
- constrain wide and tall popups to the editor bounds

## Root cause
The signature-help result populated the hover DOM but left the widget height at its factory default of `0`. The renderer therefore exposed only the CSS minimum height. Its Y coordinate also inverted the cursor position, placing the clipped popup near the bottom of the editor.

## Validation
- 587 editor-worker tests passed, 53 skipped
- 4 focused layout tests passed
- type-check passed
- lint/format/knip passed
- build passed