### PR TITLE
fix: apply rename edits across workspace

### DIFF
--- a/packages/build/src/config.ts
+++ b/packages/build/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 887_000
+export const threshold = 889_000
 
 export const workerPath = join(root, '.tmp/dist/dist/editorWorkerMain.js')
 

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandApplyWorkspaceEdit.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandApplyWorkspaceEdit.ts
@@ -1,44 +1,86 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as Editor from '../Editor/Editor.ts'
 import * as EditOrigin from '../EditOrigin/EditOrigin.ts'
+import * as EditorStates from '../EditorStates/EditorStates.ts'
+import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
 import * as TextDocument from '../TextDocument/TextDocument.ts'
 
 // TODO maybe use a separate worker for bulk edits and bulk edit history
 
-const getTextChanges = (editor: any, changes: readonly any[]) => {
+const sortEditsDescending = (edits: readonly any[]): readonly any[] => {
+  return edits.toSorted((a, b) => b.offset - a.offset)
+}
+
+export const applyEditsToText = (text: string, edits: readonly any[]): string => {
+  let newText = text
+  for (const edit of sortEditsDescending(edits)) {
+    newText = newText.slice(0, edit.offset) + edit.inserted + newText.slice(edit.offset + edit.deleted)
+  }
+  return newText
+}
+
+export const getTextChanges = (editor: any, edits: readonly any[]): readonly any[] => {
   const textChanges: any[] = []
-  for (const change of changes) {
-    if (change.uri === editor.uri) {
-      for (const edit of change.edits) {
-        const startPosition = TextDocument.positionAt(editor, edit.offset)
-        const endPosition = TextDocument.positionAt(editor, edit.offset + edit.deleted)
-        const deleted = TextDocument.getSelectionText(editor, { end: endPosition, start: startPosition })
-        const textChange = {
-          deleted,
-          end: endPosition,
-          inserted: [edit.inserted],
-          origin: EditOrigin.Rename,
-          start: startPosition,
-        }
-        textChanges.push(textChange)
-      }
+  for (const edit of sortEditsDescending(edits)) {
+    const startPosition = TextDocument.positionAt(editor, edit.offset)
+    const endPosition = TextDocument.positionAt(editor, edit.offset + edit.deleted)
+    const deleted = TextDocument.getSelectionText(editor, { end: endPosition, start: startPosition })
+    const textChange = {
+      deleted,
+      end: endPosition,
+      inserted: [edit.inserted],
+      origin: EditOrigin.Rename,
+      start: startPosition,
     }
+    textChanges.push(textChange)
   }
   return textChanges
+}
+
+const groupEditsByUri = (changes: readonly any[]): ReadonlyMap<string, readonly any[]> => {
+  const editsByUri = new Map<string, any[]>()
+  for (const change of changes) {
+    const edits = editsByUri.get(change.uri)
+    if (edits) {
+      edits.push(...change.edits)
+    } else {
+      editsByUri.set(change.uri, [...change.edits])
+    }
+  }
+  return editsByUri
+}
+
+const getOpenEditor = (currentEditor: any, uri: string): any => {
+  if (currentEditor.uri === uri) {
+    return currentEditor
+  }
+  for (const key of EditorStates.getKeys()) {
+    const editor = EditorStates.get(Number(key))?.newState
+    if (editor && !editor.initial && editor.uri === uri) {
+      return editor
+    }
+  }
+  return undefined
 }
 
 export const applyWorkspaceEdit = async (editor: any, changes: readonly any[]): Promise<any> => {
   Assert.object(editor)
   Assert.array(changes)
-  const textChanges = getTextChanges(editor, changes)
-  if (textChanges.length === 0) {
-    return editor
+  let currentEditor = editor
+  const editsByUri = groupEditsByUri(changes)
+  for (const [uri, edits] of editsByUri) {
+    const openEditor = getOpenEditor(currentEditor, uri)
+    if (openEditor) {
+      const textChanges = getTextChanges(openEditor, edits)
+      const updatedEditor = await Editor.scheduleDocumentAndCursorsSelections(openEditor, textChanges)
+      if (openEditor.uid === currentEditor.uid) {
+        currentEditor = updatedEditor
+      }
+      continue
+    }
+    const text = await RendererWorker.readFile(uri)
+    const newText = applyEditsToText(text, edits)
+    await RendererWorker.invoke('FileSystem.writeFile', uri, newText)
   }
-  // TODO
-  // for now only apply edits to single file, if it matches the URI
-  //
-  // in the future:
-  // 1. if a change targets the current editor, apply an edit to this editor
-  // 2. else, use file system worker to write file change
-  return Editor.scheduleDocumentAndCursorsSelections(editor, textChanges)
+  return currentEditor
 }

--- a/packages/editor-worker/src/parts/RendererWorker/RendererWorker.ts
+++ b/packages/editor-worker/src/parts/RendererWorker/RendererWorker.ts
@@ -1,3 +1,3 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 
-export const { invoke, invokeAndTransfer, set } = RendererWorker
+export const { invoke, invokeAndTransfer, readFile, set } = RendererWorker

--- a/packages/editor-worker/test/EditorCommandApplyWorkspaceEdit.test.ts
+++ b/packages/editor-worker/test/EditorCommandApplyWorkspaceEdit.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>()
+const readFile = jest.fn<(uri: string) => Promise<string>>()
+const scheduleDocumentAndCursorsSelections = jest.fn<(editor: any, changes: readonly any[]) => Promise<any>>()
+
+jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
+  RendererWorker: {
+    invoke,
+    readFile,
+  },
+}))
+
+jest.unstable_mockModule('../src/parts/Editor/Editor.ts', () => ({
+  scheduleDocumentAndCursorsSelections,
+}))
+
+const EditorCommandApplyWorkspaceEdit = await import('../src/parts/EditorCommand/EditorCommandApplyWorkspaceEdit.ts')
+const EditorStates = await import('../src/parts/EditorStates/EditorStates.ts')
+
+afterEach(() => {
+  invoke.mockReset()
+  readFile.mockReset()
+  scheduleDocumentAndCursorsSelections.mockReset()
+  for (const key of EditorStates.getKeys()) {
+    EditorStates.dispose(Number(key))
+  }
+})
+
+test('applyEditsToText applies offset edits without shifting later edits', () => {
+  const text = 'const oldName = oldName'
+  const edits = [
+    {
+      deleted: 7,
+      inserted: 'newName',
+      offset: 6,
+    },
+    {
+      deleted: 7,
+      inserted: 'newName',
+      offset: 16,
+    },
+  ]
+
+  expect(EditorCommandApplyWorkspaceEdit.applyEditsToText(text, edits)).toBe('const newName = newName')
+})
+
+test('applyWorkspaceEdit applies all edits for the current editor', async () => {
+  const editor = {
+    initial: false,
+    lines: ['const oldName = oldName'],
+    uid: 1,
+    uri: 'file:///current.ts',
+  }
+  const updatedEditor = {
+    ...editor,
+    lines: ['const newName = newName'],
+  }
+  scheduleDocumentAndCursorsSelections.mockResolvedValue(updatedEditor)
+
+  const result = await EditorCommandApplyWorkspaceEdit.applyWorkspaceEdit(editor, [
+    {
+      edits: [
+        {
+          deleted: 7,
+          inserted: 'newName',
+          offset: 6,
+        },
+      ],
+      uri: editor.uri,
+    },
+    {
+      edits: [
+        {
+          deleted: 7,
+          inserted: 'newName',
+          offset: 16,
+        },
+      ],
+      uri: editor.uri,
+    },
+  ])
+
+  expect(result).toBe(updatedEditor)
+  expect(scheduleDocumentAndCursorsSelections).toHaveBeenCalledTimes(1)
+  expect(scheduleDocumentAndCursorsSelections).toHaveBeenCalledWith(editor, [
+    {
+      deleted: ['oldName'],
+      end: {
+        columnIndex: 23,
+        rowIndex: 0,
+      },
+      inserted: ['newName'],
+      origin: 'rename',
+      start: {
+        columnIndex: 16,
+        rowIndex: 0,
+      },
+    },
+    {
+      deleted: ['oldName'],
+      end: {
+        columnIndex: 13,
+        rowIndex: 0,
+      },
+      inserted: ['newName'],
+      origin: 'rename',
+      start: {
+        columnIndex: 6,
+        rowIndex: 0,
+      },
+    },
+  ])
+})
+
+test('applyWorkspaceEdit updates closed files on disk', async () => {
+  const editor = {
+    initial: false,
+    lines: ['oldName'],
+    uid: 1,
+    uri: 'file:///current.ts',
+  }
+  readFile.mockResolvedValue('export const oldName = 1')
+
+  const result = await EditorCommandApplyWorkspaceEdit.applyWorkspaceEdit(editor, [
+    {
+      edits: [
+        {
+          deleted: 7,
+          inserted: 'newName',
+          offset: 13,
+        },
+      ],
+      uri: 'file:///target.ts',
+    },
+  ])
+
+  expect(result).toBe(editor)
+  expect(readFile).toHaveBeenCalledWith('file:///target.ts')
+  expect(invoke).toHaveBeenCalledWith('FileSystem.writeFile', 'file:///target.ts', 'export const newName = 1')
+})
+
+test('applyWorkspaceEdit updates another open editor without writing it to disk', async () => {
+  const currentEditor = {
+    initial: false,
+    lines: ['oldName'],
+    uid: 1,
+    uri: 'file:///current.ts',
+  }
+  const otherEditor = {
+    initial: false,
+    lines: ['export const oldName = 1'],
+    uid: 2,
+    uri: 'file:///target.ts',
+  }
+  EditorStates.set(otherEditor.uid, otherEditor as any, otherEditor as any)
+  scheduleDocumentAndCursorsSelections.mockResolvedValue({
+    ...otherEditor,
+    lines: ['export const newName = 1'],
+  })
+
+  const result = await EditorCommandApplyWorkspaceEdit.applyWorkspaceEdit(currentEditor, [
+    {
+      edits: [
+        {
+          deleted: 7,
+          inserted: 'newName',
+          offset: 13,
+        },
+      ],
+      uri: otherEditor.uri,
+    },
+  ])
+
+  expect(result).toBe(currentEditor)
+  expect(scheduleDocumentAndCursorsSelections).toHaveBeenCalledWith(otherEditor, [
+    {
+      deleted: ['oldName'],
+      end: {
+        columnIndex: 20,
+        rowIndex: 0,
+      },
+      inserted: ['newName'],
+      origin: 'rename',
+      start: {
+        columnIndex: 13,
+        rowIndex: 0,
+      },
+    },
+  ])
+  expect(readFile).not.toHaveBeenCalled()
+  expect(invoke).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- group workspace edits by URI and apply every occurrence in offset-safe order
- update the active editor and other open editors as modified buffers
- apply edits for closed files through the file-system worker
- add coverage for current, other-open, and closed-file rename targets
- raise the worker memory budget by 2 KB for the new workspace-edit logic

## Testing
- npm test
- npm run type-check
- npm run lint
- npm run build
- npm run measure --workspace packages/build