### PR TITLE
fix: preserve rename widget transitions

### DIFF
--- a/packages/editor-worker/src/parts/CreateFns/CreateFns.ts
+++ b/packages/editor-worker/src/parts/CreateFns/CreateFns.ts
@@ -50,6 +50,11 @@ const createFn = (key: string, name: string, widgetId: number) => {
     const { uid } = state
     const invoke = GetWidgetInvoke.getWidgetInvoke(widgetId)
     await invoke(`${name}.${key}`, uid, ...args)
+    const latestAfterInvoke = Editors.get(editor.uid).newState
+    const latestChildIndex = latestAfterInvoke.widgets.findIndex(isWidget)
+    if (latestChildIndex === -1) {
+      return latestAfterInvoke
+    }
     const diff = await invoke(`${name}.diff2`, uid)
     const commands = await invoke(`${name}.render2`, uid, diff)
     const latest = Editors.get(editor.uid).newState

--- a/packages/editor-worker/src/parts/RenderFocus/RenderFocus.ts
+++ b/packages/editor-worker/src/parts/RenderFocus/RenderFocus.ts
@@ -2,6 +2,9 @@ import { ViewletCommand } from '@lvce-editor/constants'
 import type { EditorState } from '../State/State.ts'
 
 export const renderFocus = (oldState: EditorState, newState: EditorState): readonly any[] => {
+  if (!newState.focused) {
+    return []
+  }
   const selector = '.EditorInput textarea'
   return [ViewletCommand.FocusSelector, newState.uid, selector]
 }

--- a/packages/editor-worker/test/CreateFns.test.ts
+++ b/packages/editor-worker/test/CreateFns.test.ts
@@ -1,0 +1,45 @@
+import { expect, jest, test } from '@jest/globals'
+import { WidgetId } from '@lvce-editor/constants'
+
+const invoke = jest.fn<(...args: any[]) => Promise<void>>()
+
+jest.unstable_mockModule('../src/parts/GetWidgetInvoke/GetWidgetInvoke.ts', () => ({
+  getWidgetInvoke: jest.fn(() => invoke),
+}))
+
+const Editors = await import('../src/parts/EditorStates/EditorStates.ts')
+const CreateFns = await import('../src/parts/CreateFns/CreateFns.ts')
+
+const editorUid = 901
+const widgetUid = 902
+
+test('accept preserves an editor transition that removed the widget', async () => {
+  const originalEditor = {
+    uid: editorUid,
+    widgets: [
+      {
+        id: WidgetId.Rename,
+        newState: {
+          uid: widgetUid,
+        },
+      },
+    ],
+  }
+  const editorWithoutRename = {
+    ...originalEditor,
+    widgets: [],
+  }
+  Editors.set(editorUid, originalEditor as any, originalEditor as any)
+  invoke.mockImplementation(async (method: string, ..._args: any[]) => {
+    if (method === 'Rename.accept') {
+      Editors.set(editorUid, originalEditor as any, editorWithoutRename as any)
+    }
+  })
+  const { accept } = CreateFns.createFns(['accept'], 'Rename', WidgetId.Rename)
+
+  await expect(accept(editorUid)).resolves.toBe(editorWithoutRename)
+  expect(invoke).toHaveBeenCalledTimes(1)
+  expect(invoke).toHaveBeenCalledWith('Rename.accept', widgetUid)
+  expect(Editors.get(editorUid).oldState).toBe(originalEditor)
+  expect(Editors.get(editorUid).newState).toBe(editorWithoutRename)
+})

--- a/packages/editor-worker/test/RenderFocus.test.ts
+++ b/packages/editor-worker/test/RenderFocus.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@jest/globals'
+import { ViewletCommand } from '@lvce-editor/constants'
+import * as RenderFocus from '../src/parts/RenderFocus/RenderFocus.ts'
+
+test('renderFocus focuses the editor textarea when the editor is focused', () => {
+  const oldState = {
+    focused: false,
+    uid: 1,
+  }
+  const newState = {
+    focused: true,
+    uid: 1,
+  }
+
+  expect(RenderFocus.renderFocus(oldState as any, newState as any)).toEqual([ViewletCommand.FocusSelector, 1, '.EditorInput textarea'])
+})
+
+test('renderFocus does not focus the editor textarea when a widget has full focus', () => {
+  const oldState = {
+    focused: true,
+    uid: 1,
+  }
+  const newState = {
+    focused: false,
+    uid: 1,
+  }
+
+  expect(RenderFocus.renderFocus(oldState as any, newState as any)).toEqual([])
+})


### PR DESCRIPTION
## Summary
- preserve editor state transitions when a widget command removes itself
- avoid refocusing the editor textarea while a full-focus widget is active
- cover rename acceptance and editor focus rendering

## Validation
- `npm run lint`
- `npm run type-check`
- focused Jest tests (3 passed)
- live browser multi-file rename verification