### PR TITLE
test: cover layout-owned widget lifecycle

### DIFF
--- a/packages/e2e/src/editor.completion-lifecycle.ts
+++ b/packages/e2e/src/editor.completion-lifecycle.ts
@@ -1,6 +1,6 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'editor.completion-dismiss-on-editor-switch'
+export const name = 'editor.completion-lifecycle'
 
 export const test: Test = async ({ Editor, expect, Extension, FileSystem, Locator, Main, Workspace }) => {
   const extensionUri = import.meta.resolve('../fixtures/editor.completion-one-result')
@@ -19,6 +19,14 @@ export const test: Test = async ({ Editor, expect, Extension, FileSystem, Locato
   await expect(completions).toBeVisible()
 
   await Main.openUri(secondFile)
+
+  await expect(completions).toBeHidden()
+
+  await Main.selectTab(0, 0)
+
+  await expect(completions).toBeVisible()
+
+  await Main.closeAllEditors()
 
   await expect(completions).toBeHidden()
 }

--- a/packages/e2e/src/editor.hover-show.ts
+++ b/packages/e2e/src/editor.hover-show.ts
@@ -19,4 +19,10 @@ export const test: Test = async ({ Command, Editor, expect, Extension, FileSyste
   const hover = Locator('.EditorHover')
   await expect(hover).toBeVisible()
   await expect(hover).toHaveText('def')
+
+  // act
+  await Main.closeAllEditors()
+
+  // assert
+  await expect(hover).toBeHidden()
 }

--- a/packages/e2e/src/find-widget-close-on-editor-close.ts
+++ b/packages/e2e/src/find-widget-close-on-editor-close.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'find-widget-close-on-editor-close'
+
+export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  const file = `${tmpDir}/find-widget-close.txt`
+  await FileSystem.writeFile(file, 'content')
+  await Main.openUri(file)
+  await Editor.openFind()
+  const findWidget = Locator('.FindWidget')
+  await expect(findWidget).toBeVisible()
+
+  // act
+  await Main.closeAllEditors()
+
+  // assert
+  await expect(findWidget).toBeHidden()
+}


### PR DESCRIPTION
## Summary

- verify completion widgets hide while their editor is unmounted, restore with retained state, and disappear on disposal
- verify open hover and find widgets disappear when their editor is closed

## Validation

- `npm test`
- `npm run type-check`
- `npm run lint`
- targeted headless e2e: completion lifecycle, hover close, find close