### PR TITLE
Fix find widget replacement actions

### DIFF
--- a/packages/editor-worker/src/parts/EditorFindWidget/EditorFindWidget.ts
+++ b/packages/editor-worker/src/parts/EditorFindWidget/EditorFindWidget.ts
@@ -23,9 +23,11 @@ const commandsToForward = [
 export const render = (widget: IFindWidget) => {
   const commands: readonly any[] = FindWidgetRender.renderFull(widget.oldState, widget.newState)
   const wrappedCommands = []
-  const { uid } = widget.newState
+  const { editorUid, uid } = widget.newState
   for (const command of commands) {
-    if (commandsToForward.includes(command[0])) {
+    if (command[0] === RenderMethod.SetFocusContext) {
+      wrappedCommands.push([command[0], editorUid, ...command.slice(1)])
+    } else if (commandsToForward.includes(command[0])) {
       wrappedCommands.push(command)
     } else {
       wrappedCommands.push(['Viewlet.send', uid, ...command])

--- a/packages/editor-worker/src/parts/FindWidgetWorkerCallbacks/FindWidgetWorkerCallbacks.ts
+++ b/packages/editor-worker/src/parts/FindWidgetWorkerCallbacks/FindWidgetWorkerCallbacks.ts
@@ -1,0 +1,46 @@
+import type { OffsetBasedEdit } from '../OffsetBasedEdit/OffsetBasedEdit.ts'
+import * as ApplyDocumentEdits from '../EditorCommand/EditorCommandApplyDocumentEdits.ts'
+import * as EditorCommandCloseFind from '../EditorCommand/EditorCommandCloseFind.ts'
+import * as Editors from '../EditorStates/EditorStates.ts'
+import * as GetEditor from '../GetEditor/GetEditor.ts'
+import * as SetFocus from '../SetFocus/SetFocus.ts'
+import * as UpdateDerivedState from '../UpdateDerivedState/UpdateDerivedState.ts'
+import * as WhenExpression from '../WhenExpression/WhenExpression.ts'
+
+const updateEditor = async (editorUid: number, editor: any, newEditor: any): Promise<void> => {
+  if (newEditor === editor) {
+    return
+  }
+  const newEditorWithDerivedState = await UpdateDerivedState.updateDerivedState(editor, newEditor)
+  Editors.set(editorUid, editor, newEditorWithDerivedState)
+}
+
+export const applyDocumentEdits = async (editorUid: number, edits: readonly OffsetBasedEdit[]): Promise<void> => {
+  const editor = GetEditor.getEditor(editorUid)
+  const newEditor = await ApplyDocumentEdits.applyDocumentEdits(editor, edits)
+  await updateEditor(editorUid, editor, newEditor)
+}
+
+export const closeFind = async (editorUid: number): Promise<void> => {
+  const editor = GetEditor.getEditor(editorUid)
+  const newEditor = EditorCommandCloseFind.closeFind(editor)
+  await updateEditor(editorUid, editor, newEditor)
+  await SetFocus.setFocus(WhenExpression.FocusEditorText)
+}
+
+export const getLines = (editorUid: number): readonly string[] => {
+  return GetEditor.getEditor(editorUid).lines
+}
+
+export const getSelections = (editorUid: number): Uint32Array => {
+  return GetEditor.getEditor(editorUid).selections
+}
+
+export const setSelections = async (editorUid: number, selections: Uint32Array): Promise<void> => {
+  const editor = GetEditor.getEditor(editorUid)
+  const newEditor = {
+    ...editor,
+    selections,
+  }
+  await updateEditor(editorUid, editor, newEditor)
+}

--- a/packages/editor-worker/src/parts/GetFindWidgetWorkerCommandMap/GetFindWidgetWorkerCommandMap.ts
+++ b/packages/editor-worker/src/parts/GetFindWidgetWorkerCommandMap/GetFindWidgetWorkerCommandMap.ts
@@ -1,0 +1,9 @@
+import * as FindWidgetWorkerCallbacks from '../FindWidgetWorkerCallbacks/FindWidgetWorkerCallbacks.ts'
+
+export const getFindWidgetWorkerCommandMap = (): Record<string, (...args: readonly any[]) => any> => ({
+  'Editor.applyDocumentEdits': FindWidgetWorkerCallbacks.applyDocumentEdits,
+  'Editor.closeFind2': FindWidgetWorkerCallbacks.closeFind,
+  'Editor.getLines2': FindWidgetWorkerCallbacks.getLines,
+  'Editor.getSelections2': FindWidgetWorkerCallbacks.getSelections,
+  'Editor.setSelections2': FindWidgetWorkerCallbacks.setSelections,
+})

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -39,6 +39,11 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusSourceActions,
     },
     {
+      command: 'FindWidget.replace',
+      key: KeyCode.Enter,
+      when: WhenExpression.FocusFindWidgetReplace,
+    },
+    {
       command: 'FindWidget.focusNext',
       key: KeyCode.Enter,
       when: WhenExpression.FocusFindWidget,

--- a/packages/editor-worker/src/parts/LaunchFindWidgetWorker/LaunchFindWidgetWorker.ts
+++ b/packages/editor-worker/src/parts/LaunchFindWidgetWorker/LaunchFindWidgetWorker.ts
@@ -1,8 +1,9 @@
 import type { Rpc } from '@lvce-editor/rpc-registry'
+import { getFindWidgetWorkerCommandMap } from '../GetFindWidgetWorkerCommandMap/GetFindWidgetWorkerCommandMap.ts'
 import { launchWorker } from '../LaunchWorker/LaunchWorker.ts'
 
 export const launchFindWidgetWorker = async (): Promise<Rpc> => {
   const name = 'Find Widget Worker'
   const url = 'findWidgetWorkerMain.js'
-  return launchWorker(name, url)
+  return launchWorker(name, url, undefined, getFindWidgetWorkerCommandMap())
 }

--- a/packages/editor-worker/src/parts/LaunchWorker/LaunchWorker.ts
+++ b/packages/editor-worker/src/parts/LaunchWorker/LaunchWorker.ts
@@ -3,9 +3,14 @@ import { TransferMessagePortRpcParent } from '@lvce-editor/rpc'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RendererWorkerIpcParentType from '../RendererWorkerIpcParentType/RendererWorkerIpcParentType.ts'
 
-export const launchWorker = async (name: string, url: string, intializeCommand?: string): Promise<Rpc> => {
+export const launchWorker = async (
+  name: string,
+  url: string,
+  intializeCommand?: string,
+  commandMap: Record<string, (...args: readonly any[]) => any> = {},
+): Promise<Rpc> => {
   const rpc = await TransferMessagePortRpcParent.create({
-    commandMap: {},
+    commandMap,
     isMessagePortOpen: true,
     async send(port) {
       await RendererWorker.invokeAndTransfer('IpcParent.create', {

--- a/packages/editor-worker/src/parts/RenderWidgets/RenderWidgets.ts
+++ b/packages/editor-worker/src/parts/RenderWidgets/RenderWidgets.ts
@@ -48,5 +48,5 @@ export const renderWidgets = (oldState: EditorState, newState: EditorState): rea
   WidgetRevision.record(newState.uid, declaredRevision)
   const widgetUids = newWidgets.map((widget) => widget.newState.uid)
   const allCommands = [...addCommands, ...changeCommands, ['Viewlet.setWidgets', newState.uid, declaredRevision, widgetUids]]
-  return allCommands.filter((item) => item[0] !== 'Viewlet.setFocusContext' && item[0] !== 'Viewlet.appendToBody')
+  return allCommands.filter((item) => item[0] !== 'Viewlet.appendToBody')
 }

--- a/packages/editor-worker/src/parts/RenderWidgets/RenderWidgets.ts
+++ b/packages/editor-worker/src/parts/RenderWidgets/RenderWidgets.ts
@@ -48,5 +48,5 @@ export const renderWidgets = (oldState: EditorState, newState: EditorState): rea
   WidgetRevision.record(newState.uid, declaredRevision)
   const widgetUids = newWidgets.map((widget) => widget.newState.uid)
   const allCommands = [...addCommands, ...changeCommands, ['Viewlet.setWidgets', newState.uid, declaredRevision, widgetUids]]
-  return allCommands.filter((item) => item[0] !== 'Viewlet.appendToBody')
+  return allCommands.filter((item) => item[0] !== 'Viewlet.appendToBody' && (item[0] !== 'Viewlet.setFocusContext' || item.length >= 3))
 }

--- a/packages/editor-worker/test/EditorFindWidget.test.ts
+++ b/packages/editor-worker/test/EditorFindWidget.test.ts
@@ -30,3 +30,23 @@ test('focusFindInput - returns the editor unchanged when find is closed', () => 
 
   expect(EditorFindWidget.focusFindInput(editor)).toBe(editor)
 })
+
+test('render - associates the editor uid with focus context commands', () => {
+  const oldState = {
+    commands: [],
+    editorUid: 3,
+    uid: 7,
+  }
+  const newState = {
+    commands: [[RenderMethod.SetFocusContext, 43]],
+    editorUid: 3,
+    uid: 7,
+  }
+  const widget = {
+    id: WidgetId.Find,
+    newState,
+    oldState,
+  }
+
+  expect(EditorFindWidget.render(widget as any)).toEqual([[RenderMethod.SetFocusContext, 3, 43]])
+})

--- a/packages/editor-worker/test/GetFindWidgetWorkerCommandMap.test.ts
+++ b/packages/editor-worker/test/GetFindWidgetWorkerCommandMap.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@jest/globals'
+import { getFindWidgetWorkerCommandMap } from '../src/parts/GetFindWidgetWorkerCommandMap/GetFindWidgetWorkerCommandMap.ts'
+
+test('provides editor callbacks to the find widget worker', () => {
+  expect(Object.keys(getFindWidgetWorkerCommandMap())).toEqual([
+    'Editor.applyDocumentEdits',
+    'Editor.closeFind2',
+    'Editor.getLines2',
+    'Editor.getSelections2',
+    'Editor.setSelections2',
+  ])
+})

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -19,6 +19,28 @@ test('Shift+Enter focuses the previous find match', () => {
   })
 })
 
+test('Enter replaces the current find match from the replace input', () => {
+  const keyBindings = GetKeyBindings.getKeyBindings()
+  const replace = {
+    command: 'FindWidget.replace',
+    key: KeyCode.Enter,
+    when: WhenExpression.FocusFindWidgetReplace,
+  }
+  const focusNext = {
+    command: 'FindWidget.focusNext',
+    key: KeyCode.Enter,
+    when: WhenExpression.FocusFindWidget,
+  }
+  expect(keyBindings).toContainEqual(replace)
+  const replaceIndex = keyBindings.findIndex(
+    (keyBinding) => keyBinding.command === replace.command && keyBinding.key === replace.key && keyBinding.when === replace.when,
+  )
+  const focusNextIndex = keyBindings.findIndex(
+    (keyBinding) => keyBinding.command === focusNext.command && keyBinding.key === focusNext.key && keyBinding.when === focusNext.when,
+  )
+  expect(replaceIndex).toBeLessThan(focusNextIndex)
+})
+
 test('Ctrl/Cmd+Alt+Up adds a cursor above', () => {
   expect(GetKeyBindings.getKeyBindings()).toContainEqual({
     command: 'Editor.addCursorAbove',

--- a/packages/editor-worker/test/RenderWidgets.test.ts
+++ b/packages/editor-worker/test/RenderWidgets.test.ts
@@ -63,7 +63,7 @@ test('renderWidgets renders added, changed, and removed widgets', () => {
   ])
 })
 
-test('renderWidgets filters focus context commands', () => {
+test('renderWidgets preserves focus context commands', () => {
   const widgetId = 804
   WidgetRegistry.set(widgetId, {
     add: () => [
@@ -88,6 +88,7 @@ test('renderWidgets filters focus context commands', () => {
   }
 
   expect(RenderWidgets.renderWidgets(oldState, newState)).toEqual([
+    ['Viewlet.setFocusContext', 1],
     ['add-widget', 1],
     ['Viewlet.setWidgets', 42, 1, [1]],
   ])

--- a/packages/editor-worker/test/RenderWidgets.test.ts
+++ b/packages/editor-worker/test/RenderWidgets.test.ts
@@ -63,11 +63,12 @@ test('renderWidgets renders added, changed, and removed widgets', () => {
   ])
 })
 
-test('renderWidgets preserves focus context commands', () => {
+test('renderWidgets preserves focus context commands associated with a parent widget', () => {
   const widgetId = 804
   WidgetRegistry.set(widgetId, {
     add: () => [
       ['Viewlet.setFocusContext', 1],
+      ['Viewlet.setFocusContext', 42, 43],
       ['add-widget', 1],
     ],
   })
@@ -88,7 +89,7 @@ test('renderWidgets preserves focus context commands', () => {
   }
 
   expect(RenderWidgets.renderWidgets(oldState, newState)).toEqual([
-    ['Viewlet.setFocusContext', 1],
+    ['Viewlet.setFocusContext', 42, 43],
     ['add-widget', 1],
     ['Viewlet.setWidgets', 42, 1, [1]],
   ])


### PR DESCRIPTION
## Summary

- expose local editor callbacks to the find-widget worker so replacement commands can update the document without a reentrant RPC deadlock
- preserve embedded-widget focus contexts and route them through the owning editor
- bind Enter in the replacement input to replace the current match

## Verification

- npm test (601 tests)
- npm run type-check
- npm run lint
- npm run build
- source-app checks for Replace, Replace All, Enter, and Ctrl+Alt+Enter