### PR TITLE
Fix editor redraw after find replacement

### DIFF
--- a/packages/e2e/src/find-widget-replace-one-occurence.ts
+++ b/packages/e2e/src/find-widget-replace-one-occurence.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.find-replace-one-occurrence'
 
-export const test: Test = async ({ Editor, FileSystem, FindWidget, Main, Workspace }) => {
+export const test: Test = async ({ Editor, expect, FileSystem, FindWidget, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(
@@ -24,4 +24,6 @@ content 2`,
   // assert
   await Editor.shouldHaveText(`replaced 1
 content 2`)
+  const editorRows = Locator('.EditorRows')
+  await expect(editorRows).toHaveText('replaced 1content 2')
 }

--- a/packages/editor-worker/src/parts/CreateFns/CreateFns.ts
+++ b/packages/editor-worker/src/parts/CreateFns/CreateFns.ts
@@ -76,7 +76,7 @@ const createFn = (key: string, name: string, widgetId: number) => {
       commands,
     }
     const newEditor = UpdateWidget.updateWidget(latest, widgetId, newState)
-    Editors.set(editor.uid, latest, newEditor)
+    Editors.set(editor.uid, editor, newEditor)
     return newEditor
   }
   return fn

--- a/packages/editor-worker/test/CreateFns.test.ts
+++ b/packages/editor-worker/test/CreateFns.test.ts
@@ -1,7 +1,7 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import { WidgetId } from '@lvce-editor/constants'
 
-const invoke = jest.fn<(...args: any[]) => Promise<void>>()
+const invoke = jest.fn<(...args: any[]) => Promise<any>>()
 
 jest.unstable_mockModule('../src/parts/GetWidgetInvoke/GetWidgetInvoke.ts', () => ({
   getWidgetInvoke: jest.fn(() => invoke),
@@ -12,6 +12,10 @@ const CreateFns = await import('../src/parts/CreateFns/CreateFns.ts')
 
 const editorUid = 901
 const widgetUid = 902
+
+beforeEach(() => {
+  invoke.mockReset()
+})
 
 test('accept preserves an editor transition that removed the widget', async () => {
   const originalEditor = {
@@ -42,4 +46,47 @@ test('accept preserves an editor transition that removed the widget', async () =
   expect(invoke).toHaveBeenCalledWith('Rename.accept', widgetUid)
   expect(Editors.get(editorUid).oldState).toBe(originalEditor)
   expect(Editors.get(editorUid).newState).toBe(editorWithoutRename)
+})
+
+test('handleInput preserves an editor transition while the widget remains open', async () => {
+  const widgetState = {
+    uid: widgetUid,
+  }
+  const originalEditor = {
+    lines: ['before'],
+    uid: editorUid,
+    widgets: [
+      {
+        id: WidgetId.Rename,
+        newState: widgetState,
+      },
+    ],
+  }
+  const updatedEditor = {
+    ...originalEditor,
+    lines: ['after'],
+  }
+  const renderCommands = [['Viewlet.setDom2', widgetUid, []]]
+  Editors.set(editorUid, originalEditor as any, originalEditor as any)
+  invoke.mockImplementation(async (method: string) => {
+    switch (method) {
+      case 'Rename.diff2':
+        return [1]
+      case 'Rename.handleInput':
+        Editors.set(editorUid, originalEditor as any, updatedEditor as any)
+        return undefined
+      case 'Rename.render2':
+        return renderCommands
+      default:
+        return undefined
+    }
+  })
+  const { handleInput } = CreateFns.createFns(['handleInput'], 'Rename', WidgetId.Rename)
+
+  const result = await handleInput(editorUid, 'value')
+
+  expect(result.lines).toEqual(['after'])
+  expect(result.widgets[0].newState.commands).toBe(renderCommands)
+  expect(Editors.get(editorUid).oldState).toBe(originalEditor)
+  expect(Editors.get(editorUid).newState).toBe(result)
 })


### PR DESCRIPTION
Summary:

- Preserve the editor pre-command render state when an embedded widget updates the editor model.
- Add a unit regression for nested editor transitions.
- Verify find replacement redraws the editor immediately in the end-to-end test.

Testing:

- npm test (602 passed, 53 skipped)
- npm run type-check
- npm run lint
- npm run build
- npm run build:static
- filtered find-widget replace e2e
- full headless e2e (204 passed, 162 skipped)