### PR TITLE
fix: notify renderer when diagnostics change

### DIFF
--- a/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
+++ b/packages/editor-worker/src/parts/UpdateDiagnostics/UpdateDiagnostics.ts
@@ -2,6 +2,7 @@ import * as EditorState from '../EditorStates/EditorStates.ts'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.ts'
 import * as ExtensionHostDiagnostic from '../ExtensionHostDiagnostic/ExtensionHostDiagnostic.ts'
 import * as GetVisibleDiagnostics from '../GetVisibleDiagnostics/GetVisibleDiagnostics.ts'
+import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
 import * as UpdateDiagnosticsWithLinks from './UpdateDiagnosticsWithLinks.ts'
 
 const getDiagnostics = async (editor: any): Promise<readonly any[]> => {
@@ -33,6 +34,14 @@ const handleError = async (error: unknown, editor: any): Promise<any> => {
   return editor
 }
 
+const notifyDiagnosticsChange = async (uri: string): Promise<void> => {
+  try {
+    await RendererWorker.invoke('Layout.handleDiagnosticsChange', uri)
+  } catch {
+    // Older renderer workers do not support diagnostics change listeners.
+  }
+}
+
 export const updateDiagnostics = async (editor: any): Promise<any> => {
   if (!editor.diagnosticsEnabled) {
     return editor
@@ -45,6 +54,7 @@ export const updateDiagnostics = async (editor: any): Promise<any> => {
     }
     const newEditor = await addDiagnostics(latest.newState, diagnostics)
     EditorState.set(editor.id, latest.oldState, newEditor)
+    await notifyDiagnosticsChange(newEditor.uri)
     return newEditor
   } catch (error) {
     return handleError(error, editor)

--- a/packages/editor-worker/test/UpdateDiagnostics.test.ts
+++ b/packages/editor-worker/test/UpdateDiagnostics.test.ts
@@ -1,12 +1,13 @@
 import { afterEach, expect, test } from '@jest/globals'
 import { MockRpc } from '@lvce-editor/rpc'
-import { ExtensionManagementWorker, registerMockRpc, remove, RpcId } from '@lvce-editor/rpc-registry'
+import { ExtensionManagementWorker, registerMockRpc, remove, RendererWorker, RpcId } from '@lvce-editor/rpc-registry'
 import * as EditorStates from '../src/parts/EditorStates/EditorStates.ts'
 import { updateDiagnostics } from '../src/parts/UpdateDiagnostics/UpdateDiagnostics.ts'
 
 afterEach(() => {
   EditorStates.dispose(1)
   remove(RpcId.ErrorWorker)
+  remove(RpcId.RendererWorker)
 })
 
 test('updateDiagnostics reports failures through the error worker', async () => {
@@ -89,4 +90,26 @@ test('updateDiagnostics ignores results after the editor is closed', async () =>
 
   await expect(pendingUpdate).resolves.toBe(editor)
   expect(EditorStates.get(1)).toBeUndefined()
+})
+
+test('updateDiagnostics notifies the renderer after storing diagnostics', async () => {
+  using extensionManagementWorkerRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeDiagnosticProvider': async () => [],
+  })
+  using rendererWorkerRpc = RendererWorker.registerMockRpc({
+    'Layout.handleDiagnosticsChange': async () => undefined,
+  })
+  const editor = {
+    diagnosticsEnabled: true,
+    id: 1,
+    languageId: 'typescript',
+    lines: ['const value = 1'],
+    uri: 'file:///test.ts',
+  }
+  EditorStates.set(1, editor as any, editor as any)
+
+  await updateDiagnostics(editor)
+
+  expect(extensionManagementWorkerRpc.invocations).toHaveLength(1)
+  expect(rendererWorkerRpc.invocations).toEqual([['Layout.handleDiagnosticsChange', 'file:///test.ts']])
 })


### PR DESCRIPTION
Notifies the renderer after updated diagnostics are stored so open diagnostic consumers such as Problems can refresh immediately.