### PR TITLE
fix: make source actions interactive

### DIFF
--- a/packages/editor-worker/src/parts/ApplyWidgetChange/ApplyWidgetChange.ts
+++ b/packages/editor-worker/src/parts/ApplyWidgetChange/ApplyWidgetChange.ts
@@ -15,5 +15,5 @@ export const applyWidgetChange = async (editor: any, widget: any, changes: any[]
       ...newState,
     }
   }
-  return widget
+  return editor
 }

--- a/packages/editor-worker/src/parts/ApplyWidgetChanges/ApplyWidgetChanges.ts
+++ b/packages/editor-worker/src/parts/ApplyWidgetChanges/ApplyWidgetChanges.ts
@@ -3,11 +3,11 @@ import * as ApplyWidgetChange from '../ApplyWidgetChange/ApplyWidgetChange.ts'
 export const applyWidgetChanges = async (editor: any, changes: any) => {
   const widgets = editor.widgets || []
   if (widgets.length === 0) {
-    return widgets
+    return editor
   }
   let latestEditor = editor
   for (const widget of widgets) {
-    latestEditor = await ApplyWidgetChange.applyWidgetChange(editor, widget, changes)
+    latestEditor = await ApplyWidgetChange.applyWidgetChange(latestEditor, widget, changes)
   }
   return latestEditor
 }

--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -305,6 +305,7 @@ export const commandMap = {
   'Editor.handleScrollBarVerticalPointerMove': wrapCommand(EditorCommandHandleScrollBarMove.handleScrollBarVerticalPointerMove),
   'Editor.handleSettingsChanged': wrapCommand(handleSettingsChanged),
   'Editor.handleSingleClick': wrapCommand(HandleSingleClick.handleSingleClick),
+  'Editor.handleSourceActionClick': EditorSourceActionWidget.selectItem,
   'Editor.handleTab': wrapCommand(HandleTab.handleTab),
   'Editor.handleTouchEnd': wrapCommand(HandleTouchEnd.handleTouchEnd),
   'Editor.handleTouchMove': wrapCommand(HandleTouchMove.handleTouchMove),

--- a/packages/editor-worker/src/parts/CreateFns/CreateFns.ts
+++ b/packages/editor-worker/src/parts/CreateFns/CreateFns.ts
@@ -56,6 +56,7 @@ const createFn = (key: string, name: string, widgetId: number) => {
     const latestAfterInvoke = Editors.get(editor.uid).newState
     const latestChildIndex = latestAfterInvoke.widgets.findIndex(isWidget)
     if (latestChildIndex === -1) {
+      Editors.set(editor.uid, editor, latestAfterInvoke)
       return latestAfterInvoke
     }
     const diff = await invoke(`${name}.diff2`, uid)

--- a/packages/editor-worker/src/parts/EditorSourceActionWidget/EditorSourceActionWidget.ts
+++ b/packages/editor-worker/src/parts/EditorSourceActionWidget/EditorSourceActionWidget.ts
@@ -21,9 +21,11 @@ const commandsToForward = [
 export const render = (widget: SourceActionWidget) => {
   const commands: readonly any[] = RenderRename.renderFull(widget.oldState, widget.newState)
   const wrappedCommands = []
-  const { uid } = widget.newState
+  const { editorUid, uid } = widget.newState
   for (const command of commands) {
-    if (commandsToForward.includes(command[0])) {
+    if (command[0] === RenderMethod.SetFocusContext) {
+      wrappedCommands.push([command[0], editorUid, ...command.slice(1)])
+    } else if (commandsToForward.includes(command[0])) {
       wrappedCommands.push(command)
     } else {
       wrappedCommands.push(['Viewlet.send', uid, ...command])

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -42,27 +42,27 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusSourceActions,
     },
     {
-      command: 'EditorSourceActions.focusNext',
+      command: 'EditorSourceAction.focusNext',
       key: KeyCode.DownArrow,
       when: WhenExpression.FocusSourceActions,
     },
     {
-      command: 'EditorSourceActions.focusPrevious',
+      command: 'EditorSourceAction.focusPrevious',
       key: KeyCode.UpArrow,
       when: WhenExpression.FocusSourceActions,
     },
     {
-      command: 'EditorSourceActions.focusFirst',
+      command: 'EditorSourceAction.focusFirst',
       key: KeyCode.Home,
       when: WhenExpression.FocusSourceActions,
     },
     {
-      command: 'EditorSourceActions.focusLast',
+      command: 'EditorSourceAction.focusLast',
       key: KeyCode.End,
       when: WhenExpression.FocusSourceActions,
     },
     {
-      command: 'EditorSourceActions.selectCurrent',
+      command: 'EditorSourceAction.selectCurrent',
       key: KeyCode.Enter,
       when: WhenExpression.FocusSourceActions,
     },

--- a/packages/editor-worker/src/parts/SourceActionState/SourceActionState.ts
+++ b/packages/editor-worker/src/parts/SourceActionState/SourceActionState.ts
@@ -1,5 +1,6 @@
 export interface SourceActionState {
   readonly commands: readonly any[]
+  readonly editorUid: number
   readonly focusedIndex: number
   readonly height: number
   readonly maxHeight: number

--- a/packages/editor-worker/src/parts/SourceActionWidgetFactory/SourceActionWidgetFactory.ts
+++ b/packages/editor-worker/src/parts/SourceActionWidgetFactory/SourceActionWidgetFactory.ts
@@ -8,6 +8,7 @@ export const create = (): SourceActionWidget => {
     id: WidgetId.SourceAction,
     newState: {
       commands: [],
+      editorUid: 0,
       focusedIndex: 0,
       height: 0,
       maxHeight: 0,
@@ -19,6 +20,7 @@ export const create = (): SourceActionWidget => {
     },
     oldState: {
       commands: [],
+      editorUid: 0,
       focusedIndex: 0,
       height: 0,
       maxHeight: 0,

--- a/packages/editor-worker/test/ApplyWidgetChange.test.ts
+++ b/packages/editor-worker/test/ApplyWidgetChange.test.ts
@@ -77,7 +77,7 @@ test('applyWidgetChange - deleteLeft', async () => {
   expect((await ApplyWidgetChange.applyWidgetChange(editor, widget, changes)).newState).toBeUndefined()
 })
 
-test('applyWidgetChange - other', async () => {
+test('applyWidgetChange - other preserves the editor', async () => {
   const editor = {
     cursor: {
       columnIndex: 4,
@@ -103,7 +103,5 @@ test('applyWidgetChange - other', async () => {
       origin: EditOrigin.Unknown,
     },
   ]
-  expect((await ApplyWidgetChange.applyWidgetChange(editor, widget, changes)).newState).toEqual({
-    updated: false,
-  })
+  expect(await ApplyWidgetChange.applyWidgetChange(editor, widget, changes)).toBe(editor)
 })

--- a/packages/editor-worker/test/ApplyWidgetChanges.test.ts
+++ b/packages/editor-worker/test/ApplyWidgetChanges.test.ts
@@ -8,12 +8,12 @@ const id = 1
 
 beforeEach(() => {
   WidgetRegistry.set(id, {
-    handleEditorDeleteLeft: (editor: any, state: any) => ({
-      ...state,
+    handleEditorDeleteLeft: (editor: any) => ({
+      ...editor,
       updated: true,
     }),
-    handleEditorType: (editor: any, state: any) => ({
-      ...state,
+    handleEditorType: (editor: any) => ({
+      ...editor,
       updated: true,
     }),
   })
@@ -48,6 +48,7 @@ test('applyWidgetChanges - delete', async () => {
     },
   ]
   expect(await ApplyWidgetChanges.applyWidgetChanges(editor, changes)).toEqual({
+    ...editor,
     updated: true,
   })
 })
@@ -70,5 +71,59 @@ test('applyWidgetChanges - empty widgets', async () => {
       origin: EditOrigin.DeleteLeft,
     },
   ]
-  expect(await ApplyWidgetChanges.applyWidgetChanges(editor, changes)).toEqual([])
+  expect(await ApplyWidgetChanges.applyWidgetChanges(editor, changes)).toBe(editor)
+})
+
+test('applyWidgetChanges preserves editor identity for unrelated edits', async () => {
+  const editor = {
+    id: 123,
+    lines: ['before'],
+    uid: 123,
+    widgets: [
+      {
+        id,
+        newState: {},
+        oldState: {},
+      },
+    ],
+  }
+  const changes = [
+    {
+      deleted: ['before'],
+      inserted: ['after'],
+      origin: EditOrigin.Format,
+    },
+  ]
+
+  await expect(ApplyWidgetChanges.applyWidgetChanges(editor, changes)).resolves.toBe(editor)
+})
+
+test('applyWidgetChanges passes each widget the latest editor', async () => {
+  const secondId = 2
+  WidgetRegistry.set(secondId, {
+    handleEditorType: (editor: any) => ({
+      ...editor,
+      secondUpdated: editor.updated,
+    }),
+  })
+  const editor = {
+    lines: ['before'],
+    widgets: [
+      { id, newState: {}, oldState: {} },
+      { id: secondId, newState: {}, oldState: {} },
+    ],
+  }
+  const changes = [
+    {
+      deleted: [],
+      inserted: ['a'],
+      origin: EditOrigin.EditorType,
+    },
+  ]
+
+  await expect(ApplyWidgetChanges.applyWidgetChanges(editor, changes)).resolves.toEqual({
+    ...editor,
+    secondUpdated: true,
+    updated: true,
+  })
 })

--- a/packages/editor-worker/test/CreateFns.test.ts
+++ b/packages/editor-worker/test/CreateFns.test.ts
@@ -48,6 +48,40 @@ test('accept preserves an editor transition that removed the widget', async () =
   expect(Editors.get(editorUid).newState).toBe(editorWithoutRename)
 })
 
+test('accept preserves the pre-command state when a nested transition removed the widget', async () => {
+  const originalEditor = {
+    lines: ['before'],
+    uid: editorUid,
+    widgets: [
+      {
+        id: WidgetId.Rename,
+        newState: {
+          uid: widgetUid,
+        },
+      },
+    ],
+  }
+  const updatedEditor = {
+    ...originalEditor,
+    lines: ['after'],
+  }
+  const editorWithoutRename = {
+    ...updatedEditor,
+    widgets: [],
+  }
+  Editors.set(editorUid, originalEditor as any, originalEditor as any)
+  invoke.mockImplementation(async (method: string, ..._args: any[]) => {
+    if (method === 'Rename.accept') {
+      Editors.set(editorUid, updatedEditor as any, editorWithoutRename as any)
+    }
+  })
+  const { accept } = CreateFns.createFns(['accept'], 'Rename', WidgetId.Rename)
+
+  await expect(accept(editorUid)).resolves.toBe(editorWithoutRename)
+  expect(Editors.get(editorUid).oldState).toBe(originalEditor)
+  expect(Editors.get(editorUid).newState).toBe(editorWithoutRename)
+})
+
 test('handleInput preserves an editor transition while the widget remains open', async () => {
   const widgetState = {
     uid: widgetUid,

--- a/packages/editor-worker/test/EditorSourceActionWidget.test.ts
+++ b/packages/editor-worker/test/EditorSourceActionWidget.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@jest/globals'
+import { WidgetId } from '@lvce-editor/constants'
+import * as EditorSourceActionWidget from '../src/parts/EditorSourceActionWidget/EditorSourceActionWidget.ts'
+import * as RenderMethod from '../src/parts/RenderMethod/RenderMethod.ts'
+
+test('render - associates the editor uid with focus context commands', () => {
+  const oldState = {
+    commands: [],
+    editorUid: 3,
+    uid: 7,
+  }
+  const newState = {
+    commands: [[RenderMethod.SetFocusContext, 38]],
+    editorUid: 3,
+    uid: 7,
+  }
+  const widget = {
+    id: WidgetId.SourceAction,
+    newState,
+    oldState,
+  }
+
+  expect(EditorSourceActionWidget.render(widget as any)).toEqual([[RenderMethod.SetFocusContext, 3, 38]])
+})

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -12,6 +12,38 @@ test('Escape closes the focused color picker', () => {
   })
 })
 
+test('source action keybindings use the editor source action widget commands', () => {
+  expect(GetKeyBindings.getKeyBindings()).toEqual(
+    expect.arrayContaining([
+      {
+        command: 'EditorSourceAction.focusNext',
+        key: KeyCode.DownArrow,
+        when: WhenExpression.FocusSourceActions,
+      },
+      {
+        command: 'EditorSourceAction.focusPrevious',
+        key: KeyCode.UpArrow,
+        when: WhenExpression.FocusSourceActions,
+      },
+      {
+        command: 'EditorSourceAction.focusFirst',
+        key: KeyCode.Home,
+        when: WhenExpression.FocusSourceActions,
+      },
+      {
+        command: 'EditorSourceAction.focusLast',
+        key: KeyCode.End,
+        when: WhenExpression.FocusSourceActions,
+      },
+      {
+        command: 'EditorSourceAction.selectCurrent',
+        key: KeyCode.Enter,
+        when: WhenExpression.FocusSourceActions,
+      },
+    ]),
+  )
+})
+
 test('Shift+Enter focuses the previous find match', () => {
   expect(GetKeyBindings.getKeyBindings()).toContainEqual({
     command: 'FindWidget.focusPrevious',

--- a/packages/editor-worker/test/SourceActionWidgetFactory.test.ts
+++ b/packages/editor-worker/test/SourceActionWidgetFactory.test.ts
@@ -3,5 +3,6 @@ import * as SourceActionWidgetFactory from '../src/parts/SourceActionWidgetFacto
 
 test('create', () => {
   const widget = SourceActionWidgetFactory.create()
-  expect(widget).toBeDefined()
+  expect(widget.newState.editorUid).toBe(0)
+  expect(widget.oldState.editorUid).toBe(0)
 })


### PR DESCRIPTION
## Details

Wire source-action mouse and keyboard commands, associate nested focus-context commands with their editor, and preserve the full editor transition when a source action removes its widget.

Also fixes widget-change handling so unrelated document edits preserve the editor identity and diagnostics rather than merging a widget object into editor state.

## Tests

- `npm test` (full suite)
- `npm run type-check`
- `npm run lint`
- `npm run build`
- Local LVCE UI: quote and semicolon quick fixes applied; Problems updated 2 → 1 → 0; Up/Down and Enter verified