### PR TITLE
fix: auto save editor changes after delay

### DIFF
--- a/packages/e2e/src/editor.auto-save-after-delay.ts
+++ b/packages/e2e/src/editor.auto-save-after-delay.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-auto-save-after-delay'
+
+const waitForAutoSave = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 1200))
+}
+
+export const test: Test = async ({ Command, Editor, FileSystem, Main, Settings, Workspace }) => {
+  await Settings.update({ 'files.autoSave': 'afterDelay' })
+  const tmpDir = await FileSystem.getTmpDir()
+  const filePath = `${tmpDir}/auto-save-after-delay.txt`
+  await FileSystem.writeFile(filePath, 'abc')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(filePath)
+  await Editor.setCursor(0, 3)
+
+  await Editor.type('d')
+  await waitForAutoSave()
+  await FileSystem.shouldHaveFile(filePath, 'abcd')
+
+  await Command.execute('Editor.undo')
+  await waitForAutoSave()
+  await FileSystem.shouldHaveFile(filePath, 'abc')
+
+  await Settings.update({ 'files.autoSave': 'off' })
+}

--- a/packages/editor-worker/src/parts/AutoSave/AutoSave.ts
+++ b/packages/editor-worker/src/parts/AutoSave/AutoSave.ts
@@ -1,0 +1,54 @@
+const autoSaveDelay = 1000
+
+interface PendingSave {
+  readonly timeout: ReturnType<typeof setTimeout>
+  readonly token: number
+}
+
+const pendingSaves = new Map<number, PendingSave>()
+
+const state = {
+  nextToken: 0,
+}
+
+const run = async (uid: number, token: number, save: (token: number) => Promise<void>): Promise<void> => {
+  if (!isLatest(uid, token)) {
+    return
+  }
+  await save(token)
+}
+
+export const schedule = (uid: number, save: (token: number) => Promise<void>): void => {
+  dispose(uid)
+  const token = ++state.nextToken
+  const timeout = setTimeout(run, autoSaveDelay, uid, token, save)
+  pendingSaves.set(uid, { timeout, token })
+}
+
+export const isLatest = (uid: number, token: number): boolean => {
+  return pendingSaves.get(uid)?.token === token
+}
+
+export const consume = (uid: number, token: number): void => {
+  if (!isLatest(uid, token)) {
+    return
+  }
+  dispose(uid)
+}
+
+export const dispose = (uid: number): void => {
+  const pendingSave = pendingSaves.get(uid)
+  if (!pendingSave) {
+    return
+  }
+  clearTimeout(pendingSave.timeout)
+  pendingSaves.delete(uid)
+}
+
+export const reset = (): void => {
+  for (const pendingSave of pendingSaves.values()) {
+    clearTimeout(pendingSave.timeout)
+  }
+  pendingSaves.clear()
+  state.nextToken = 0
+}

--- a/packages/editor-worker/src/parts/DisposeEditor/DisposeEditor.ts
+++ b/packages/editor-worker/src/parts/DisposeEditor/DisposeEditor.ts
@@ -1,4 +1,5 @@
 import { WidgetId } from '@lvce-editor/constants'
+import * as AutoSave from '../AutoSave/AutoSave.ts'
 import * as ColorPickerWorker from '../ColorPickerWorker/ColorPickerWorker.ts'
 import * as EditorStates from '../EditorStates/EditorStates.ts'
 import * as RenderWidgets from '../RenderWidgets/RenderWidgets.ts'
@@ -19,6 +20,7 @@ export const disposeEditor = async (editorUid: number): Promise<readonly any[]> 
     widgets: [],
   })
   WidgetRevision.dispose(editorUid)
+  AutoSave.dispose(editorUid)
   EditorStates.dispose(editorUid)
   return commands
 }

--- a/packages/editor-worker/src/parts/WrapCommands/WrapCommands.ts
+++ b/packages/editor-worker/src/parts/WrapCommands/WrapCommands.ts
@@ -1,9 +1,39 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { EditorState } from '../State/State.ts'
+import * as AutoSave from '../AutoSave/AutoSave.ts'
+import * as EditorCommandSave from '../EditorCommand/EditorCommandSave.ts'
 import { editorDiagnosticEffect } from '../EditorDiagnosticEffect/EditorDiagnosticEffect.ts'
 import * as Editors from '../EditorStates/EditorStates.ts'
 import { emptyIncrementalEdits } from '../EmptyIncrementalEdits/EmptyIncrementalEdits.ts'
+import * as Preferences from '../Preferences/Preferences.ts'
 import * as UpdateDerivedState from '../UpdateDerivedState/UpdateDerivedState.ts'
 
 const queues: Record<string, Promise<void> | undefined> = {}
+
+const saveAfterDelay = async (uid: number, token: number): Promise<void> => {
+  if (!Editors.get(uid)) {
+    AutoSave.consume(uid, token)
+    return
+  }
+  let didSave = false
+  const save = wrapCommand(async (editor: EditorState) => {
+    if (!AutoSave.isLatest(uid, token)) {
+      return editor
+    }
+    AutoSave.consume(uid, token)
+    const autoSave = await Preferences.get('files.autoSave')
+    if (autoSave !== 'afterDelay') {
+      return editor
+    }
+    const savedEditor = await EditorCommandSave.save(editor)
+    didSave = savedEditor !== editor
+    return savedEditor
+  })
+  await save(uid)
+  if (didSave) {
+    await RendererWorker.invoke('Editor.renderPending', uid)
+  }
+}
 
 // TODO wrap commands globally, not per editor
 // TODO only store editor state in editor worker, not in renderer worker also
@@ -66,6 +96,11 @@ export const wrapCommand =
           })
           Editors.set(otherUid, instance.oldState, synchronizedEditor)
         }
+      }
+      if (lines !== finalEditor.lines) {
+        AutoSave.schedule(uid, (token) => saveAfterDelay(uid, token))
+      } else if (modified && !finalEditor.modified) {
+        AutoSave.dispose(uid)
       }
       return finalEditor
     } finally {

--- a/packages/editor-worker/test/AutoSave.test.ts
+++ b/packages/editor-worker/test/AutoSave.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+
+const AutoSave = await import('../src/parts/AutoSave/AutoSave.ts')
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  AutoSave.reset()
+})
+
+afterEach(() => {
+  AutoSave.reset()
+  jest.useRealTimers()
+})
+
+test('runs a pending save after the delay', async () => {
+  const save = jest.fn<(token: number) => Promise<void>>().mockResolvedValue()
+
+  AutoSave.schedule(1, save)
+  await jest.advanceTimersByTimeAsync(999)
+
+  expect(save).not.toHaveBeenCalled()
+
+  await jest.advanceTimersByTimeAsync(1)
+
+  expect(save).toHaveBeenCalledWith(1)
+})
+
+test('debounces repeated document changes', async () => {
+  const save = jest.fn<(token: number) => Promise<void>>().mockResolvedValue()
+
+  AutoSave.schedule(1, save)
+  await jest.advanceTimersByTimeAsync(700)
+  AutoSave.schedule(1, save)
+  await jest.advanceTimersByTimeAsync(999)
+
+  expect(save).not.toHaveBeenCalled()
+
+  await jest.advanceTimersByTimeAsync(1)
+
+  expect(save).toHaveBeenCalledWith(2)
+})
+
+test('tracks and consumes the latest pending save', async () => {
+  const save = jest.fn<(token: number) => Promise<void>>().mockResolvedValue()
+
+  AutoSave.schedule(1, save)
+
+  expect(AutoSave.isLatest(1, 1)).toBe(true)
+
+  AutoSave.consume(1, 1)
+
+  expect(AutoSave.isLatest(1, 1)).toBe(false)
+})
+
+test('disposes a pending save', async () => {
+  const save = jest.fn<(token: number) => Promise<void>>().mockResolvedValue()
+
+  AutoSave.schedule(1, save)
+  AutoSave.dispose(1)
+  await jest.advanceTimersByTimeAsync(1000)
+
+  expect(save).not.toHaveBeenCalled()
+})

--- a/packages/editor-worker/test/WrapCommands.test.ts
+++ b/packages/editor-worker/test/WrapCommands.test.ts
@@ -3,6 +3,34 @@ import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
 const updateDerivedStateMock = jest.fn()
 const editorDiagnosticEffectApplyMock: any = jest.fn()
 const editorDiagnosticEffectIsActiveMock: any = jest.fn()
+const autoSaveScheduleMock = jest.fn<(uid: number, save: (token: number) => Promise<void>) => void>()
+const autoSaveIsLatestMock = jest.fn<(uid: number, token: number) => boolean>()
+const autoSaveConsumeMock = jest.fn<(uid: number, token: number) => void>()
+const autoSaveDisposeMock = jest.fn<(uid: number) => void>()
+const saveMock = jest.fn()
+const getPreferenceMock = jest.fn<(key: string) => Promise<string>>()
+const rendererInvokeMock = jest.fn()
+
+jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
+  RendererWorker: {
+    invoke: rendererInvokeMock,
+  },
+}))
+
+jest.unstable_mockModule('../src/parts/AutoSave/AutoSave.ts', () => ({
+  consume: autoSaveConsumeMock,
+  dispose: autoSaveDisposeMock,
+  isLatest: autoSaveIsLatestMock,
+  schedule: autoSaveScheduleMock,
+}))
+
+jest.unstable_mockModule('../src/parts/EditorCommand/EditorCommandSave.ts', () => ({
+  save: saveMock,
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.ts', () => ({
+  get: getPreferenceMock,
+}))
 
 jest.unstable_mockModule('../src/parts/UpdateDerivedState/UpdateDerivedState.ts', () => ({
   updateDerivedState: updateDerivedStateMock,
@@ -32,6 +60,19 @@ beforeEach(() => {
     await Promise.resolve()
     return newState
   })
+  autoSaveScheduleMock.mockReset()
+  autoSaveIsLatestMock.mockReset()
+  autoSaveIsLatestMock.mockReturnValue(true)
+  autoSaveConsumeMock.mockReset()
+  autoSaveDisposeMock.mockReset()
+  saveMock.mockReset()
+  saveMock.mockImplementation(async (editor: any) => ({
+    ...editor,
+    modified: false,
+  }))
+  getPreferenceMock.mockReset()
+  getPreferenceMock.mockResolvedValue('afterDelay')
+  rendererInvokeMock.mockReset()
 })
 
 afterEach(() => {
@@ -147,6 +188,152 @@ test('synchronizes document state with another editor showing the same uri', asy
     modified: true,
     undoStack: [edit],
   })
+  expect(autoSaveScheduleMock).toHaveBeenCalledWith(1, expect.any(Function))
+})
+
+test('schedules auto save when undo changes a modified document', async () => {
+  const state = {
+    initial: false,
+    lines: ['edited'],
+    modified: true,
+    redoStack: [],
+    uid: 1,
+    undoStack: [[{ inserted: ['edited'] }]],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    lines: ['original'],
+    redoStack: editor.undoStack,
+    undoStack: [],
+  }))
+
+  await command(1)
+
+  expect(autoSaveScheduleMock).toHaveBeenCalledWith(1, expect.any(Function))
+})
+
+test('scheduled auto save uses the latest modified editor state', async () => {
+  const state = {
+    initial: false,
+    lines: ['original'],
+    modified: false,
+    redoStack: [],
+    uid: 1,
+    undoStack: [],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    lines: ['edited'],
+    modified: true,
+  }))
+
+  await command(1)
+  const saveAfterDelay = autoSaveScheduleMock.mock.calls[0][1]
+  await saveAfterDelay(1)
+
+  expect(getPreferenceMock).toHaveBeenCalledWith('files.autoSave')
+  expect(saveMock).toHaveBeenCalledWith(expect.objectContaining({ lines: ['edited'], modified: true }))
+  expect(EditorStates.get(1).newState).toMatchObject({ lines: ['edited'], modified: false })
+  expect(rendererInvokeMock).toHaveBeenCalledWith('Editor.renderPending', 1)
+})
+
+test('scheduled auto save persists a document change even when modified is false', async () => {
+  const state = {
+    initial: false,
+    lines: ['original'],
+    modified: false,
+    redoStack: [],
+    uid: 1,
+    undoStack: [],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    lines: ['edited'],
+  }))
+
+  await command(1)
+  const saveAfterDelay = autoSaveScheduleMock.mock.calls[0][1]
+  await saveAfterDelay(1)
+
+  expect(saveMock).toHaveBeenCalledWith(expect.objectContaining({ lines: ['edited'], modified: false }))
+  expect(rendererInvokeMock).toHaveBeenCalledWith('Editor.renderPending', 1)
+})
+
+test('cancels a pending auto save when the editor is saved explicitly', async () => {
+  const state = {
+    initial: false,
+    lines: ['edited'],
+    modified: true,
+    redoStack: [],
+    uid: 1,
+    undoStack: [],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    modified: false,
+  }))
+
+  await command(1)
+
+  expect(autoSaveDisposeMock).toHaveBeenCalledWith(1)
+  expect(autoSaveScheduleMock).not.toHaveBeenCalled()
+})
+
+test('scheduled auto save does not save when the setting is off', async () => {
+  const state = {
+    initial: false,
+    lines: ['original'],
+    modified: false,
+    redoStack: [],
+    uid: 1,
+    undoStack: [],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    lines: ['edited'],
+    modified: true,
+  }))
+  getPreferenceMock.mockResolvedValue('off')
+
+  await command(1)
+  const saveAfterDelay = autoSaveScheduleMock.mock.calls[0][1]
+  await saveAfterDelay(1)
+
+  expect(saveMock).not.toHaveBeenCalled()
+  expect(EditorStates.get(1).newState.modified).toBe(true)
+  expect(rendererInvokeMock).not.toHaveBeenCalled()
+})
+
+test('does not schedule auto save when document text is unchanged', async () => {
+  const state = {
+    initial: false,
+    lines: ['abc'],
+    modified: true,
+    redoStack: [],
+    selection: 0,
+    uid: 1,
+    undoStack: [],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    selection: 1,
+  }))
+
+  await command(1)
+
+  expect(autoSaveScheduleMock).not.toHaveBeenCalled()
 })
 
 test('does not synchronize document state with another uri', async () => {


### PR DESCRIPTION
## Details

Implement the `files.autoSave: afterDelay` behavior in the editor worker. Content-changing commands now schedule a debounced save, including Undo/Redo changes that occur while the editor remains focused.

The delayed callback revalidates the latest editor state and setting inside the editor command queue. Explicit saves and editor disposal cancel pending work, and successful asynchronous saves request a renderer update.

## Tests

- `npm test` (620 tests passed)
- `npm test -- --runInBand --coverage=false AutoSave.test.ts WrapCommands.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm run e2e:headless --workspace=e2e -- --filter=auto-save-after-delay` (focused edit and Undo both persisted without blur)