### PR TITLE
fix: preserve go to definition feedback

### DIFF
--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandGoTo.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandGoTo.ts
@@ -43,15 +43,18 @@ export const goTo = async ({ editor, getErrorMessage, getLocation, getNoLocation
     return editor
   } catch (error) {
     // TODO if editor is already disposed at this point, do nothing
+    if (error === null || error === undefined) {
+      const info = EditorGetWordAt.getWordAt(editor, rowIndex, columnIndex)
+      const message = getNoLocationFoundMessage(info)
+      return EditorShowMessage.editorShowMessage(editor, rowIndex, columnIndex, message, false)
+    }
     if (isNoProviderFoundError(error)) {
       const displayErrorMessage = getErrorMessage(error)
-      await EditorShowMessage.editorShowMessage(editor, rowIndex, columnIndex, displayErrorMessage, false)
-      return editor
+      return EditorShowMessage.editorShowMessage(editor, rowIndex, columnIndex, displayErrorMessage, false)
     }
     // @ts-ignore
     // ErrorHandling.handleError(error, false)
     const displayErrorMessage = getErrorMessage(error)
-    await EditorShowMessage.editorShowMessage(editor, rowIndex, columnIndex, displayErrorMessage, true)
-    return editor
+    return EditorShowMessage.editorShowMessage(editor, rowIndex, columnIndex, displayErrorMessage, true)
   }
 }

--- a/packages/editor-worker/test/EditorCommandGoTo.test.ts
+++ b/packages/editor-worker/test/EditorCommandGoTo.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@jest/globals'
+import * as EditorCommandGoTo from '../src/parts/EditorCommand/EditorCommandGoTo.ts'
+
+const createEditor = () => ({
+  columnWidth: 8,
+  lines: ['missingDefinition'],
+  rowHeight: 20,
+  selections: new Uint32Array([0, 8, 0, 8]),
+  uid: 1,
+  uri: 'file:///test.ts',
+  widgets: [],
+  x: 10,
+  y: 30,
+})
+
+const getNoLocationFoundMessage = ({ word }: { readonly word: string }): string => `No definition found for '${word}'`
+
+test('goTo shows a message when the provider returns no definition', async () => {
+  const editor = createEditor()
+
+  const result = await EditorCommandGoTo.goTo({
+    editor,
+    getErrorMessage: String,
+    getLocation: async () => null,
+    getNoLocationFoundMessage,
+    isNoProviderFoundError: () => false,
+  })
+
+  expect(result.widgets).toEqual([
+    {
+      id: 9,
+      newState: {
+        message: "No definition found for 'missingDefinition'",
+        uid: expect.any(Number),
+        x: 74,
+        y: 50,
+      },
+    },
+  ])
+})
+
+test('goTo preserves the provider error message in the editor state', async () => {
+  const editor = createEditor()
+
+  const result = await EditorCommandGoTo.goTo({
+    editor,
+    getErrorMessage: String,
+    getLocation: async () => {
+      throw new Error('definition provider failed')
+    },
+    getNoLocationFoundMessage,
+    isNoProviderFoundError: () => false,
+  })
+
+  expect(result.widgets[0].newState.message).toBe('Error: definition provider failed')
+})
+
+test('goTo treats an empty provider rejection as no definition', async () => {
+  const editor = createEditor()
+
+  const result = await EditorCommandGoTo.goTo({
+    editor,
+    getErrorMessage: String,
+    getLocation: async () => {
+      throw null
+    },
+    getNoLocationFoundMessage,
+    isNoProviderFoundError: () => false,
+  })
+
+  expect(result.widgets[0].newState.message).toBe("No definition found for 'missingDefinition'")
+})


### PR DESCRIPTION
## Summary
- keep overlay-message state returned by failed Go to commands
- treat empty provider rejections as a no-definition result
- add focused coverage for no-result and error paths

## Verification
- npm test --workspace=packages/editor-worker -- --runInBand --coverage=false
- npm run lint
- npm run type-check