### PR TITLE
fix: reveal externally supplied selections

### DIFF
--- a/packages/editor-worker/src/parts/ExternalGetPositionAtCursor/ExternalGetPositionAtCursor.ts
+++ b/packages/editor-worker/src/parts/ExternalGetPositionAtCursor/ExternalGetPositionAtCursor.ts
@@ -1,4 +1,5 @@
 import { WidgetId } from '@lvce-editor/constants'
+import * as EditorSelection from '../Editor/EditorSelection.ts'
 import * as ApplyEdit from '../EditorCommand/EditorCommandApplyEdit.ts'
 import * as EditorCommandGetWordAt from '../EditorCommand/EditorCommandGetWordAt.ts'
 import * as Editors from '../EditorStates/EditorStates.ts'
@@ -65,7 +66,7 @@ export const getSelections2 = (editorUid: number): Uint32Array => {
 
 export const setSelections2 = async (editorUid: number, selections: Uint32Array): Promise<void> => {
   const editor = GetEditor.getEditor(editorUid)
-  const newEditor = { ...editor, selections }
+  const newEditor = EditorSelection.setSelections(editor, selections)
   const newEditorWithDerivedState = await UpdateDerivedState.updateDerivedState(editor, newEditor)
   Editors.set(editorUid, editor, newEditorWithDerivedState)
 }

--- a/packages/editor-worker/test/ExternalSetSelections.test.ts
+++ b/packages/editor-worker/test/ExternalSetSelections.test.ts
@@ -1,0 +1,36 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/UpdateDerivedState/UpdateDerivedState.ts', () => ({
+  updateDerivedState: jest.fn(async (_oldEditor, newEditor) => newEditor),
+}))
+
+const EditorStates = await import('../src/parts/EditorStates/EditorStates.ts')
+const ExternalGetPositionAtCursor = await import('../src/parts/ExternalGetPositionAtCursor/ExternalGetPositionAtCursor.ts')
+
+test('setSelections2 reveals the supplied selection', async () => {
+  const editorUid = 1
+  const editor = {
+    deltaY: 0,
+    finalDeltaY: 40,
+    height: 20,
+    itemHeight: 20,
+    lineCache: [],
+    lines: ['line 1', 'line 2', 'line 3'],
+    maxLineY: 1,
+    minLineY: 0,
+    numberOfVisibleLines: 1,
+    scrollBarHeight: 10,
+    selections: new Uint32Array([0, 0, 0, 0]),
+    uid: editorUid,
+  }
+  EditorStates.set(editorUid, editor as any, editor as any)
+
+  await ExternalGetPositionAtCursor.setSelections2(editorUid, new Uint32Array([2, 0, 2, 0]))
+
+  expect(EditorStates.get(editorUid)?.newState).toMatchObject({
+    deltaY: 40,
+    maxLineY: 3,
+    minLineY: 2,
+    selections: new Uint32Array([2, 0, 2, 0]),
+  })
+})


### PR DESCRIPTION
## Summary

- route externally supplied editor selections through the existing reveal-aware selection logic
- preserve derived-state updates after adjusting the viewport
- add a regression test that opens a selection below the visible viewport

## Tests

- `npm test -- --runInBand --coverage=false ExternalSetSelections.test.ts`
- `npm test -- --runInBand` (190 suites, 624 tests)
- `npm run type-check`
- `npm run lint`
- `npm run build`