### PR TITLE
fix: show diagnostics in editor hover

### DIFF
--- a/packages/e2e/src/editor.diagnostic-hover.ts
+++ b/packages/e2e/src/editor.diagnostic-hover.ts
@@ -1,0 +1,45 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'editor.diagnostic-hover'
+
+export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator, Main, Settings, Workspace }) => {
+  // arrange
+  await Settings.update({ 'editor.hover': true })
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/test.txt`
+  await FileSystem.writeFile(uri, 'abcdefgh')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Command.execute('Editor.setDiagnostics', [
+    {
+      code: 'rule-a',
+      columnIndex: 0,
+      endColumnIndex: 8,
+      endRowIndex: 0,
+      message: 'Example diagnostic',
+      rowIndex: 0,
+      source: 'diagnostic-test',
+      type: 'error',
+      uri,
+    },
+  ])
+  const diagnostic = Locator('.Diagnostic')
+  await expect(diagnostic).toBeVisible()
+
+  // act
+  await Editor.setCursor(0, 2)
+  await Command.execute('Editor.showHover')
+
+  // assert
+  const hover = Locator('.EditorHover')
+  await expect(hover).toBeVisible()
+  await expect(hover).toContainText('Example diagnostic')
+  await expect(hover).toContainText('diagnostic-test (rule-a)')
+
+  // act
+  await Editor.setCursor(0, 8)
+  await Command.execute('Editor.showHover')
+
+  // assert
+  await expect(hover).toBeHidden()
+}

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandHandleMouseMove.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandHandleMouseMove.ts
@@ -43,7 +43,7 @@ const onHoverIdle = async (token: number) => {
   }
 }
 
-const hoverDelay = 300
+const hoverDelay = 200
 
 export const handleMouseMove = async (editor: any, x: number, y: number, altKey: boolean) => {
   if (altKey) {

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandShowHover.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandShowHover.ts
@@ -4,8 +4,42 @@ import * as AddWidgetToEditor from '../AddWidgetToEditor/AddWidgetToEditor.ts'
 import * as FocusKey from '../FocusKey/FocusKey.ts'
 import * as HoverWidgetFactory from '../HoverWidgetFactory/HoverWidgetFactory.ts'
 import * as LoadHoverContent from '../LoadHoverContent/LoadHoverContent.ts'
+import * as RemoveEditorWidget from '../RemoveEditorWidget/RemoveEditorWidget.ts'
+import * as UpdateWidget from '../UpdateWidget/UpdateWidget.ts'
+import * as WidgetRevision from '../WidgetRevision/WidgetRevision.ts'
+
+const getHoverWidgetIndex = (widgets: readonly any[]): number => {
+  return widgets.findIndex((widget) => widget.id === WidgetId.Hover)
+}
+
+const updateHover = async (editor: any, widgetIndex: number, position: any): Promise<any> => {
+  const widgetRevision = WidgetRevision.next(editor.uid)
+  const widget = editor.widgets[widgetIndex]
+  const newState = await LoadHoverContent.loadHoverContent(widget.newState, position)
+  if (WidgetRevision.get(editor.uid) !== widgetRevision) {
+    return editor
+  }
+  if (!newState) {
+    return {
+      ...editor,
+      additionalFocus: FocusKey.Empty,
+      focused: true,
+      widgetRevision,
+      widgets: RemoveEditorWidget.removeEditorWidget(editor.widgets, WidgetId.Hover),
+    }
+  }
+  return {
+    ...UpdateWidget.updateWidget(editor, WidgetId.Hover, newState),
+    widgetRevision,
+  }
+}
 
 export const showHover = async (editor: any, position?: any): Promise<any> => {
+  const { widgets = [] } = editor
+  const widgetIndex = getHoverWidgetIndex(widgets)
+  if (widgetIndex !== -1) {
+    return updateHover(editor, widgetIndex, position)
+  }
   const newStateGenerator = async (state: HoverState): Promise<HoverState | undefined> => {
     return LoadHoverContent.loadHoverContent(state, position)
   }

--- a/packages/editor-worker/src/parts/GetHoverInfo/GetHoverInfo.ts
+++ b/packages/editor-worker/src/parts/GetHoverInfo/GetHoverInfo.ts
@@ -19,14 +19,36 @@ const getHoverPosition = (position: any, selections: any) => {
   }
 }
 
+const containsPosition = (diagnostic: any, rowIndex: number, columnIndex: number): boolean => {
+  const { columnIndex: startColumnIndex, endColumnIndex, endRowIndex, rowIndex: startRowIndex } = diagnostic
+  if (rowIndex < startRowIndex || rowIndex > endRowIndex) {
+    return false
+  }
+  if (rowIndex === startRowIndex && columnIndex < startColumnIndex) {
+    return false
+  }
+  if (rowIndex === endRowIndex && columnIndex >= endColumnIndex) {
+    return false
+  }
+  return true
+}
+
 const getMatchingDiagnostics = (diagnostics: any, rowIndex: number, columnIndex: number) => {
   const matching: any[] = []
   for (const diagnostic of diagnostics) {
-    if (diagnostic.rowIndex === rowIndex) {
+    if (containsPosition(diagnostic, rowIndex, columnIndex)) {
       matching.push(diagnostic)
     }
   }
   return matching
+}
+
+const getHover = async (editor: any, offset: number): Promise<any> => {
+  try {
+    return await Hover.getHover(editor, offset)
+  } catch {
+    return undefined
+  }
 }
 
 const fallbackDisplayStringLanguageId = 'typescript' // TODO remove this
@@ -57,17 +79,17 @@ export const getEditorHoverInfo = async (editorUid: number, position: any) => {
   const { selections } = editor
   const { columnIndex, rowIndex } = getHoverPosition(position, selections)
   const offset = TextDocument.offsetAt(editor, rowIndex, columnIndex)
-  const hover = await Hover.getHover(editor, offset)
-  if (!hover) {
+  const diagnostics = editor.diagnostics || []
+  const matchingDiagnostics = getMatchingDiagnostics(diagnostics, rowIndex, columnIndex)
+  const hover = await getHover(editor, offset)
+  if (!hover && matchingDiagnostics.length === 0) {
     return undefined
   }
-  const { displayString, displayStringLanguageId, documentation } = hover
+  const { displayString = '', displayStringLanguageId = '', documentation = '' } = hover || {}
   const tokenizerPath = ''
-  const lineInfos = await TokenizeCodeBlock.tokenizeCodeBlock(
-    displayString,
-    displayStringLanguageId || fallbackDisplayStringLanguageId,
-    tokenizerPath,
-  )
+  const lineInfos = displayString
+    ? await TokenizeCodeBlock.tokenizeCodeBlock(displayString, displayStringLanguageId || fallbackDisplayStringLanguageId, tokenizerPath)
+    : []
   const wordPart = GetWordAt.getWordBefore(editor, rowIndex, columnIndex)
   const wordStart = columnIndex - wordPart.length
   const documentationHeight = await MeasureTextHeight.measureTextBlockHeight(
@@ -78,8 +100,6 @@ export const getEditorHoverInfo = async (editorUid: number, position: any) => {
     hoverDocumentationWidth,
   )
   const { x, y } = getHoverPositionXy(editor, rowIndex, wordStart, documentationHeight)
-  const diagnostics = editor.diagnostics || []
-  const matchingDiagnostics = getMatchingDiagnostics(diagnostics, rowIndex, columnIndex)
   return {
     documentation,
     lineInfos,

--- a/packages/editor-worker/test/EditorCommandHandleMouseMove.test.ts
+++ b/packages/editor-worker/test/EditorCommandHandleMouseMove.test.ts
@@ -80,7 +80,11 @@ test('handleMouseMove - opens hover at the mouse position after the hover delay'
   })
 
   await EditorCommandHandleMouseMove.handleMouseMove(editorWithHover, 25, 10, false)
-  await jest.advanceTimersByTimeAsync(300)
+  await jest.advanceTimersByTimeAsync(199)
+
+  expect(showHover).not.toHaveBeenCalled()
+
+  await jest.advanceTimersByTimeAsync(1)
 
   expect(showHover).toHaveBeenCalledWith(
     editorWithHover,
@@ -90,4 +94,26 @@ test('handleMouseMove - opens hover at the mouse position after the hover delay'
     }),
   )
   expect(Editors.get(editor.uid).newState.widgets).toEqual([{ id: 'hover' }])
+})
+
+test('handleMouseMove - commits hover removal after moving away', async () => {
+  jest.useFakeTimers()
+  const editorWithHover = {
+    ...editor,
+    hoverEnabled: true,
+    widgets: [{ id: 'hover' }],
+  }
+  Editors.set(editor.uid, editorWithHover as any, editorWithHover as any)
+  showHover.mockImplementationOnce(async (latestEditor: any) => ({
+    ...latestEditor,
+    widgets: [],
+  }))
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'Editor.renderPending': jest.fn(),
+  })
+
+  await EditorCommandHandleMouseMove.handleMouseMove(editorWithHover, 100, 10, false)
+  await jest.advanceTimersByTimeAsync(200)
+
+  expect(Editors.get(editor.uid).newState.widgets).toEqual([])
 })

--- a/packages/editor-worker/test/EditorCommandShowHover.test.ts
+++ b/packages/editor-worker/test/EditorCommandShowHover.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { WidgetId } from '@lvce-editor/constants'
+import * as WidgetRevision from '../src/parts/WidgetRevision/WidgetRevision.ts'
+
+const loadHoverContent = jest.fn<(...args: any[]) => Promise<any>>()
+
+jest.unstable_mockModule('../src/parts/LoadHoverContent/LoadHoverContent.ts', () => ({
+  loadHoverContent,
+}))
+
+const EditorCommandShowHover = await import('../src/parts/EditorCommand/EditorCommandShowHover.ts')
+
+const hoverState = {
+  commands: [],
+  content: '',
+  diagnostics: [],
+  documentation: '',
+  editorUid: 1,
+  height: 0,
+  lineInfos: [],
+  uid: 2,
+  width: 0,
+  x: 0,
+  y: 0,
+}
+
+const hoverWidget = {
+  id: WidgetId.Hover,
+  newState: hoverState,
+  oldState: hoverState,
+}
+
+const editor = {
+  additionalFocus: 51,
+  focused: false,
+  uid: 1,
+  widgets: [hoverWidget],
+}
+
+afterEach(() => {
+  loadHoverContent.mockReset()
+  WidgetRevision.reset()
+})
+
+test('removes an existing hover when the new pointer position has no content', async () => {
+  loadHoverContent.mockResolvedValue(undefined)
+
+  const result = await EditorCommandShowHover.showHover(editor, { columnIndex: 20, rowIndex: 0 })
+
+  expect(result.widgets).toEqual([])
+  expect(result.additionalFocus).toBe(0)
+  expect(result.focused).toBe(true)
+})
+
+test('updates an existing hover at the new pointer position', async () => {
+  const newState = {
+    ...hoverState,
+    diagnostics: [{ message: 'new diagnostic' }],
+    x: 100,
+  }
+  loadHoverContent.mockResolvedValue(newState)
+
+  const result = await EditorCommandShowHover.showHover(editor, { columnIndex: 8, rowIndex: 0 })
+
+  expect(result.widgets).toEqual([
+    {
+      ...hoverWidget,
+      newState,
+      oldState: hoverState,
+    },
+  ])
+})

--- a/packages/editor-worker/test/GetHoverInfo.test.ts
+++ b/packages/editor-worker/test/GetHoverInfo.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import * as Editors from '../src/parts/EditorStates/EditorStates.ts'
+
+const getHover = jest.fn<(...args: any[]) => Promise<any>>()
+const measureTextBlockHeight = jest.fn(async () => 20)
+const tokenizeCodeBlock = jest.fn(async () => [])
+
+jest.unstable_mockModule('../src/parts/Hover/Hover.ts', () => ({
+  getHover,
+}))
+
+jest.unstable_mockModule('../src/parts/MeasureTextHeight/MeasureTextHeight.ts', () => ({
+  measureTextBlockHeight,
+}))
+
+jest.unstable_mockModule('../src/parts/TokenizeCodeBlock/TokenizeCodeBlock.ts', () => ({
+  tokenizeCodeBlock,
+}))
+
+const GetHoverInfo = await import('../src/parts/GetHoverInfo/GetHoverInfo.ts')
+
+const diagnostic = {
+  code: 'no-unused-vars',
+  columnIndex: 6,
+  endColumnIndex: 17,
+  endRowIndex: 0,
+  message: "'unusedValue' is assigned a value but never used.",
+  rowIndex: 0,
+  source: 'eslint',
+  type: 'error',
+  uri: 'file:///test.js',
+}
+
+const editor = {
+  columnWidth: 10,
+  diagnostics: [diagnostic],
+  height: 400,
+  lines: ['const unusedValue = 1'],
+  rowHeight: 20,
+  selections: [0, 0],
+  uid: 1,
+  x: 0,
+  y: 0,
+}
+
+afterEach(() => {
+  Editors.dispose(editor.uid)
+  getHover.mockReset()
+  measureTextBlockHeight.mockClear()
+  tokenizeCodeBlock.mockClear()
+})
+
+test('returns diagnostic hover info when no language hover provider exists', async () => {
+  getHover.mockRejectedValue(new Error('No hover provider found'))
+  Editors.set(editor.uid, editor as any, editor as any)
+
+  const result = await GetHoverInfo.getEditorHoverInfo(editor.uid, {
+    columnIndex: 8,
+    rowIndex: 0,
+  })
+
+  expect(result).toEqual({
+    documentation: '',
+    lineInfos: [],
+    matchingDiagnostics: [diagnostic],
+    x: 60,
+    y: 420,
+  })
+  expect(tokenizeCodeBlock).not.toHaveBeenCalled()
+})
+
+test('returns no hover info outside the diagnostic range when no language hover exists', async () => {
+  getHover.mockResolvedValue(undefined)
+  Editors.set(editor.uid, editor as any, editor as any)
+
+  const result = await GetHoverInfo.getEditorHoverInfo(editor.uid, {
+    columnIndex: 2,
+    rowIndex: 0,
+  })
+
+  expect(result).toBeUndefined()
+})
+
+test('matches a diagnostic on each covered row but excludes its end position', async () => {
+  getHover.mockResolvedValue(undefined)
+  const multilineDiagnostic = {
+    ...diagnostic,
+    columnIndex: 3,
+    endColumnIndex: 4,
+    endRowIndex: 1,
+  }
+  const multilineEditor = {
+    ...editor,
+    diagnostics: [multilineDiagnostic],
+    lines: ['first line', 'second line'],
+  }
+  Editors.set(editor.uid, multilineEditor as any, multilineEditor as any)
+
+  await expect(GetHoverInfo.getEditorHoverInfo(editor.uid, { columnIndex: 8, rowIndex: 0 })).resolves.toEqual(
+    expect.objectContaining({ matchingDiagnostics: [multilineDiagnostic] }),
+  )
+  await expect(GetHoverInfo.getEditorHoverInfo(editor.uid, { columnIndex: 3, rowIndex: 1 })).resolves.toEqual(
+    expect.objectContaining({ matchingDiagnostics: [multilineDiagnostic] }),
+  )
+  await expect(GetHoverInfo.getEditorHoverInfo(editor.uid, { columnIndex: 4, rowIndex: 1 })).resolves.toBeUndefined()
+})


### PR DESCRIPTION
Show diagnostic details in the editor hover even when the language has no hover provider.

Match diagnostics by their exact ranges, refresh or close an existing hover after pointer movement, and use a 200 ms hover delay. Adds focused unit and end-to-end coverage.