### PR TITLE
fix: position editor hover within viewport

### DIFF
--- a/packages/e2e/src/editor.diagnostic-hover.ts
+++ b/packages/e2e/src/editor.diagnostic-hover.ts
@@ -35,6 +35,8 @@ export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator,
   await expect(hover).toBeVisible()
   await expect(hover).toContainText('Example diagnostic')
   await expect(hover).toContainText('diagnostic-test (rule-a)')
+  await expect(hover).toHaveCSS('height', '30px')
+  await expect(hover).toHaveCSS('top', '75px')
 
   // act
   await Editor.setCursor(0, 8)

--- a/packages/editor-worker/src/parts/EditorHover/EditorHover.ts
+++ b/packages/editor-worker/src/parts/EditorHover/EditorHover.ts
@@ -5,12 +5,14 @@ export const loadContent = async (editorUid: number, state: any, position: any) 
   if (!hoverInfo) {
     return state
   }
-  const { documentation, lineInfos, matchingDiagnostics, x, y } = hoverInfo
+  const { documentation, height, lineInfos, matchingDiagnostics, width, x, y } = hoverInfo
   return {
     ...state,
     diagnostics: matchingDiagnostics,
     documentation,
+    height,
     lineInfos,
+    width,
     x,
     y,
   }

--- a/packages/editor-worker/src/parts/EditorHover/EditorHover.ts
+++ b/packages/editor-worker/src/parts/EditorHover/EditorHover.ts
@@ -5,14 +5,13 @@ export const loadContent = async (editorUid: number, state: any, position: any) 
   if (!hoverInfo) {
     return state
   }
-  const { documentation, height, lineInfos, matchingDiagnostics, width, x, y } = hoverInfo
+  const { documentation, height, lineInfos, matchingDiagnostics, x, y } = hoverInfo
   return {
     ...state,
     diagnostics: matchingDiagnostics,
     documentation,
     height,
     lineInfos,
-    width,
     x,
     y,
   }

--- a/packages/editor-worker/src/parts/GetHoverInfo/GetHoverInfo.ts
+++ b/packages/editor-worker/src/parts/GetHoverInfo/GetHoverInfo.ts
@@ -60,13 +60,48 @@ const hoverBorderLeft = 1
 const hoverBorderRight = 1
 const hoverPaddingLeft = 8
 const hoverPaddingRight = 8
-const hovverFullWidth = 400
-const hoverDocumentationWidth = hovverFullWidth - hoverPaddingLeft - hoverPaddingRight - hoverBorderLeft - hoverBorderRight
+const hoverBorderHeight = 2
+const hoverSectionBorderHeight = 1
+const hoverSectionGap = 3
+const hoverSectionPaddingHeight = 8
+const hoverMinHeight = 20
+const hoverMaxWidth = 600
+const hoverDocumentationWidth = hoverMaxWidth - hoverPaddingLeft - hoverPaddingRight - hoverBorderLeft - hoverBorderRight
 
-const getHoverPositionXy = (editor: any, rowIndex: number, wordStart: any, documentationHeight: any) => {
-  const x = EditorPosition.x(editor, rowIndex, wordStart)
-  const y = editor.height - EditorPosition.y(editor, rowIndex) + editor.y + 40
+const getHoverHeight = (editor: any, lineInfos: readonly any[], documentation: string, documentationHeight: number, diagnostics: readonly any[]) => {
+  let height = hoverBorderHeight
+  let sectionCount = 0
+  if (diagnostics.length > 0) {
+    height += editor.rowHeight + hoverSectionPaddingHeight
+    sectionCount++
+  }
+  if (lineInfos.length > 0) {
+    height += lineInfos.length * editor.rowHeight + hoverSectionPaddingHeight
+    if (sectionCount > 0) {
+      height += hoverSectionBorderHeight
+    }
+    sectionCount++
+  }
+  if (documentation) {
+    height += documentationHeight + hoverSectionPaddingHeight
+    sectionCount++
+  }
+  height += Math.max(0, sectionCount - 1) * hoverSectionGap
+  return Math.min(Math.max(height, hoverMinHeight), editor.height)
+}
+
+const getHoverBounds = (editor: any, rowIndex: number, wordStart: number, height: number) => {
+  const width = Math.min(hoverMaxWidth, editor.width)
+  const editorRight = editor.x + editor.width
+  const preferredX = EditorPosition.x(editor, rowIndex, wordStart)
+  const x = Math.max(editor.x, Math.min(preferredX, editorRight - width))
+  const rowBottom = EditorPosition.y(editor, rowIndex)
+  const rowTop = rowBottom - editor.rowHeight
+  const editorBottom = editor.y + editor.height
+  const y = rowBottom + height <= editorBottom ? rowBottom : Math.max(editor.y, rowTop - height)
   return {
+    height,
+    width,
     x,
     y,
   }
@@ -99,11 +134,14 @@ export const getEditorHoverInfo = async (editorUid: number, position: any) => {
     hoverDocumentationLineHeight,
     hoverDocumentationWidth,
   )
-  const { x, y } = getHoverPositionXy(editor, rowIndex, wordStart, documentationHeight)
+  const height = getHoverHeight(editor, lineInfos, documentation, documentationHeight, matchingDiagnostics)
+  const { width, x, y } = getHoverBounds(editor, rowIndex, wordStart, height)
   return {
     documentation,
+    height,
     lineInfos,
     matchingDiagnostics,
+    width,
     x,
     y,
   }

--- a/packages/editor-worker/src/parts/GetHoverInfo/GetHoverInfo.ts
+++ b/packages/editor-worker/src/parts/GetHoverInfo/GetHoverInfo.ts
@@ -7,18 +7,6 @@ import * as MeasureTextHeight from '../MeasureTextHeight/MeasureTextHeight.ts'
 import * as TextDocument from '../TextDocument/TextDocument.ts'
 import * as TokenizeCodeBlock from '../TokenizeCodeBlock/TokenizeCodeBlock.ts'
 
-const getHoverPosition = (position: any, selections: any) => {
-  if (position) {
-    return position
-  }
-  const rowIndex = selections[0]
-  const columnIndex = selections[1]
-  return {
-    columnIndex,
-    rowIndex,
-  }
-}
-
 const containsPosition = (diagnostic: any, rowIndex: number, columnIndex: number): boolean => {
   const { columnIndex: startColumnIndex, endColumnIndex, endRowIndex, rowIndex: startRowIndex } = diagnostic
   if (rowIndex < startRowIndex || rowIndex > endRowIndex) {
@@ -43,80 +31,27 @@ const getMatchingDiagnostics = (diagnostics: any, rowIndex: number, columnIndex:
   return matching
 }
 
-const getHover = async (editor: any, offset: number): Promise<any> => {
-  try {
-    return await Hover.getHover(editor, offset)
-  } catch {
-    return undefined
-  }
-}
-
 const fallbackDisplayStringLanguageId = 'typescript' // TODO remove this
 
 const hoverDocumentationFontSize = 15
 const hoverDocumentationFontFamily = 'Fira Code'
 const hoverDocumentationLineHeight = '1.33333'
-const hoverBorderLeft = 1
-const hoverBorderRight = 1
-const hoverPaddingLeft = 8
-const hoverPaddingRight = 8
-const hoverBorderHeight = 2
-const hoverSectionBorderHeight = 1
-const hoverSectionGap = 3
-const hoverSectionPaddingHeight = 8
-const hoverMinHeight = 20
-const hoverMaxWidth = 600
-const hoverDocumentationWidth = hoverMaxWidth - hoverPaddingLeft - hoverPaddingRight - hoverBorderLeft - hoverBorderRight
-
-const getHoverHeight = (editor: any, lineInfos: readonly any[], documentation: string, documentationHeight: number, diagnostics: readonly any[]) => {
-  let height = hoverBorderHeight
-  let sectionCount = 0
-  if (diagnostics.length > 0) {
-    height += editor.rowHeight + hoverSectionPaddingHeight
-    sectionCount++
-  }
-  if (lineInfos.length > 0) {
-    height += lineInfos.length * editor.rowHeight + hoverSectionPaddingHeight
-    if (sectionCount > 0) {
-      height += hoverSectionBorderHeight
-    }
-    sectionCount++
-  }
-  if (documentation) {
-    height += documentationHeight + hoverSectionPaddingHeight
-    sectionCount++
-  }
-  height += Math.max(0, sectionCount - 1) * hoverSectionGap
-  return Math.min(Math.max(height, hoverMinHeight), editor.height)
-}
-
-const getHoverBounds = (editor: any, rowIndex: number, wordStart: number, height: number) => {
-  const width = Math.min(hoverMaxWidth, editor.width)
-  const editorRight = editor.x + editor.width
-  const preferredX = EditorPosition.x(editor, rowIndex, wordStart)
-  const x = Math.max(editor.x, Math.min(preferredX, editorRight - width))
-  const rowBottom = EditorPosition.y(editor, rowIndex)
-  const rowTop = rowBottom - editor.rowHeight
-  const editorBottom = editor.y + editor.height
-  const y = rowBottom + height <= editorBottom ? rowBottom : Math.max(editor.y, rowTop - height)
-  return {
-    height,
-    width,
-    x,
-    y,
-  }
-}
+const hoverWidth = 600
+const hoverDocumentationWidth = hoverWidth - 18
 
 export const getEditorHoverInfo = async (editorUid: number, position: any) => {
   Assert.number(editorUid)
   const instance = Editors.get(editorUid)
   const editor = instance.newState
   const { selections } = editor
-  const { columnIndex, rowIndex } = getHoverPosition(position, selections)
+  const { columnIndex, rowIndex } = position || { columnIndex: selections[1], rowIndex: selections[0] }
   const offset = TextDocument.offsetAt(editor, rowIndex, columnIndex)
   const diagnostics = editor.diagnostics || []
   const matchingDiagnostics = getMatchingDiagnostics(diagnostics, rowIndex, columnIndex)
-  const hover = await getHover(editor, offset)
+  let hover
+  try {
+    hover = await Hover.getHover(editor, offset)
+  } catch {}
   if (!hover && matchingDiagnostics.length === 0) {
     return undefined
   }
@@ -134,14 +69,20 @@ export const getEditorHoverInfo = async (editorUid: number, position: any) => {
     hoverDocumentationLineHeight,
     hoverDocumentationWidth,
   )
-  const height = getHoverHeight(editor, lineInfos, documentation, documentationHeight, matchingDiagnostics)
-  const { width, x, y } = getHoverBounds(editor, rowIndex, wordStart, height)
+  const height = Math.min(
+    (matchingDiagnostics.length > 0 ? 30 : 0) +
+      (lineInfos.length > 0 ? lineInfos.length * editor.rowHeight + 12 : 0) +
+      (documentation ? documentationHeight + 11 : 0) || 20,
+    editor.height,
+  )
+  const x = Math.max(editor.x, Math.min(EditorPosition.x(editor, rowIndex, wordStart), editor.x + editor.width - hoverWidth))
+  const rowBottom = EditorPosition.y(editor, rowIndex)
+  const y = rowBottom + height <= editor.y + editor.height ? rowBottom : Math.max(editor.y, rowBottom - editor.rowHeight - height)
   return {
     documentation,
     height,
     lineInfos,
     matchingDiagnostics,
-    width,
     x,
     y,
   }

--- a/packages/editor-worker/src/parts/LoadHoverContent/LoadHoverContent.ts
+++ b/packages/editor-worker/src/parts/LoadHoverContent/LoadHoverContent.ts
@@ -6,14 +6,14 @@ export const loadHoverContent = async (state: HoverState, position?: any): Promi
   if (!hoverInfo) {
     return undefined
   }
-  const { documentation, height, lineInfos, matchingDiagnostics, width, x, y } = hoverInfo
+  const { documentation, height, lineInfos, matchingDiagnostics, x, y } = hoverInfo
   return {
     ...state,
     diagnostics: matchingDiagnostics,
     documentation,
     height,
     lineInfos,
-    width,
+    width: 600,
     x,
     y,
   }

--- a/packages/editor-worker/src/parts/LoadHoverContent/LoadHoverContent.ts
+++ b/packages/editor-worker/src/parts/LoadHoverContent/LoadHoverContent.ts
@@ -6,13 +6,14 @@ export const loadHoverContent = async (state: HoverState, position?: any): Promi
   if (!hoverInfo) {
     return undefined
   }
-  const { documentation, lineInfos, matchingDiagnostics, x, y } = hoverInfo
+  const { documentation, height, lineInfos, matchingDiagnostics, width, x, y } = hoverInfo
   return {
     ...state,
     diagnostics: matchingDiagnostics,
     documentation,
+    height,
     lineInfos,
-    width: 600,
+    width,
     x,
     y,
   }

--- a/packages/editor-worker/test/GetHoverInfo.test.ts
+++ b/packages/editor-worker/test/GetHoverInfo.test.ts
@@ -3,7 +3,7 @@ import * as Editors from '../src/parts/EditorStates/EditorStates.ts'
 
 const getHover = jest.fn<(...args: any[]) => Promise<any>>()
 const measureTextBlockHeight = jest.fn(async () => 20)
-const tokenizeCodeBlock = jest.fn(async () => [])
+const tokenizeCodeBlock = jest.fn<(...args: any[]) => Promise<any[]>>(async () => [])
 
 jest.unstable_mockModule('../src/parts/Hover/Hover.ts', () => ({
   getHover,
@@ -39,6 +39,7 @@ const editor = {
   rowHeight: 20,
   selections: [0, 0],
   uid: 1,
+  width: 800,
   x: 0,
   y: 0,
 }
@@ -61,12 +62,32 @@ test('returns diagnostic hover info when no language hover provider exists', asy
 
   expect(result).toEqual({
     documentation: '',
+    height: 30,
     lineInfos: [],
     matchingDiagnostics: [diagnostic],
+    width: 600,
     x: 60,
-    y: 420,
+    y: 20,
   })
   expect(tokenizeCodeBlock).not.toHaveBeenCalled()
+})
+
+test('sizes a combined diagnostic and language hover to its content', async () => {
+  getHover.mockResolvedValue({
+    displayString: 'const unusedValue: 1',
+    displayStringLanguageId: 'typescript',
+    documentation: '',
+  })
+  const lineInfos = [['const unusedValue: 1']]
+  tokenizeCodeBlock.mockResolvedValueOnce(lineInfos)
+  Editors.set(editor.uid, editor as any, editor as any)
+
+  const result = await GetHoverInfo.getEditorHoverInfo(editor.uid, {
+    columnIndex: 8,
+    rowIndex: 0,
+  })
+
+  expect(result).toEqual(expect.objectContaining({ height: 62, lineInfos, y: 20 }))
 })
 
 test('returns no hover info outside the diagnostic range when no language hover exists', async () => {
@@ -103,4 +124,50 @@ test('matches a diagnostic on each covered row but excludes its end position', a
     expect.objectContaining({ matchingDiagnostics: [multilineDiagnostic] }),
   )
   await expect(GetHoverInfo.getEditorHoverInfo(editor.uid, { columnIndex: 4, rowIndex: 1 })).resolves.toBeUndefined()
+})
+
+test('places the hover above a diagnostic when it does not fit below', async () => {
+  getHover.mockResolvedValue(undefined)
+  const bottomDiagnostic = {
+    ...diagnostic,
+    columnIndex: 0,
+    endColumnIndex: 4,
+    endRowIndex: 19,
+    rowIndex: 19,
+  }
+  const bottomEditor = {
+    ...editor,
+    diagnostics: [bottomDiagnostic],
+    lines: 'test\n'.repeat(20).trimEnd().split('\n'),
+  }
+  Editors.set(editor.uid, bottomEditor as any, bottomEditor as any)
+
+  const result = await GetHoverInfo.getEditorHoverInfo(editor.uid, {
+    columnIndex: 2,
+    rowIndex: 19,
+  })
+
+  expect(result).toEqual(expect.objectContaining({ height: 30, y: 350 }))
+})
+
+test('clamps the hover width and horizontal position to the editor', async () => {
+  getHover.mockResolvedValue(undefined)
+  const rightDiagnostic = {
+    ...diagnostic,
+    columnIndex: 70,
+    endColumnIndex: 75,
+  }
+  const rightEditor = {
+    ...editor,
+    diagnostics: [rightDiagnostic],
+    lines: [' '.repeat(80)],
+  }
+  Editors.set(editor.uid, rightEditor as any, rightEditor as any)
+
+  const result = await GetHoverInfo.getEditorHoverInfo(editor.uid, {
+    columnIndex: 72,
+    rowIndex: 0,
+  })
+
+  expect(result).toEqual(expect.objectContaining({ width: 600, x: 200 }))
 })

--- a/packages/editor-worker/test/GetHoverInfo.test.ts
+++ b/packages/editor-worker/test/GetHoverInfo.test.ts
@@ -65,7 +65,6 @@ test('returns diagnostic hover info when no language hover provider exists', asy
     height: 30,
     lineInfos: [],
     matchingDiagnostics: [diagnostic],
-    width: 600,
     x: 60,
     y: 20,
   })
@@ -169,5 +168,5 @@ test('clamps the hover width and horizontal position to the editor', async () =>
     rowIndex: 0,
   })
 
-  expect(result).toEqual(expect.objectContaining({ width: 600, x: 200 }))
+  expect(result).toEqual(expect.objectContaining({ x: 200 }))
 })


### PR DESCRIPTION
## Summary

- size editor hover widgets to their diagnostic, language, and documentation content
- place hovers below the source row or above it when needed
- clamp hover width and horizontal position to the editor viewport

## Validation

- 12 focused editor-worker unit tests
- targeted editor.diagnostic-hover e2e with top and height assertions
- editor-worker and e2e type checks
- full lint and formatting checks
- production and static builds