### PR TITLE
fix: dismiss editor hover with escape

### DIFF
--- a/packages/e2e/src/editor.diagnostic-hover.ts
+++ b/packages/e2e/src/editor.diagnostic-hover.ts
@@ -39,6 +39,18 @@ export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator,
   await expect(hover).toHaveCSS('top', '75px')
 
   // act
+  await Editor.cancelSelection()
+
+  // assert
+  await expect(hover).toBeHidden()
+
+  // act
+  await Command.execute('Editor.showHover')
+
+  // assert
+  await expect(hover).toBeVisible()
+
+  // act
   await Editor.setCursor(0, 8)
   await Command.execute('Editor.showHover')
 

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandCancelSelection.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandCancelSelection.ts
@@ -1,8 +1,20 @@
+import { WidgetId } from '@lvce-editor/constants'
 import * as Editor from '../Editor/Editor.ts'
 import * as EditorSelection from '../EditorSelection/EditorSelection.ts'
+import * as RemoveEditorWidget from '../RemoveEditorWidget/RemoveEditorWidget.ts'
+import * as WidgetRevision from '../WidgetRevision/WidgetRevision.ts'
 
 export const cancelSelection = (editor: any) => {
-  const { selections } = editor
+  const { selections, widgets = [] } = editor
+  if (widgets.some((widget: any) => widget.id === WidgetId.Hover)) {
+    return {
+      ...editor,
+      additionalFocus: 0,
+      focused: true,
+      widgetRevision: WidgetRevision.next(editor.uid),
+      widgets: RemoveEditorWidget.removeEditorWidget(widgets, WidgetId.Hover),
+    }
+  }
   if (selections.length === 4 && selections[0] === selections[2] && selections[1] === selections[3]) {
     return editor
   }

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -37,6 +37,11 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusColorPicker,
     },
     {
+      command: 'Editor.cancelSelection',
+      key: KeyCode.Escape,
+      when: FocusKey.FocusEditorHover,
+    },
+    {
       command: 'Editor.closeSourceAction',
       key: KeyCode.Escape,
       when: WhenExpression.FocusSourceActions,

--- a/packages/editor-worker/test/EditorCancelSelection.test.ts
+++ b/packages/editor-worker/test/EditorCancelSelection.test.ts
@@ -1,6 +1,13 @@
-import { expect, test } from '@jest/globals'
+import { afterEach, expect, test } from '@jest/globals'
+import { WidgetId } from '@lvce-editor/constants'
 import * as EditorCancelSelection from '../src/parts/EditorCommand/EditorCommandCancelSelection.ts'
 import * as EditorSelection from '../src/parts/EditorSelection/EditorSelection.ts'
+import * as FocusKey from '../src/parts/FocusKey/FocusKey.ts'
+import * as WidgetRevision from '../src/parts/WidgetRevision/WidgetRevision.ts'
+
+afterEach(() => {
+  WidgetRevision.reset()
+})
 
 test('editorCancelSelection', () => {
   const editor = {
@@ -26,4 +33,33 @@ test('editorCancelSelection - when there is no selection', () => {
   expect(EditorCancelSelection.cancelSelection(editor)).toMatchObject({
     selections: EditorSelection.fromRange(0, 4, 0, 4),
   })
+})
+
+test('editorCancelSelection - closes an open hover before cancelling the selection', () => {
+  const hover = {
+    id: WidgetId.Hover,
+    newState: { uid: 2 },
+    oldState: { uid: 2 },
+  }
+  const selections = EditorSelection.fromRange(0, 0, 0, 4)
+  const editor = {
+    additionalFocus: FocusKey.FocusEditorHover,
+    focused: true,
+    lineCache: [],
+    lines: ['line 1'],
+    selections,
+    uid: 1,
+    widgetRevision: 9,
+    widgets: [hover],
+  }
+
+  const result = EditorCancelSelection.cancelSelection(editor)
+
+  expect(result).toEqual({
+    ...editor,
+    additionalFocus: 0,
+    widgetRevision: 1,
+    widgets: [],
+  })
+  expect(result.selections).toBe(selections)
 })

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -231,3 +231,11 @@ test('Escape closes focused editor completions', () => {
     when: WhenExpression.FocusEditorCompletions,
   })
 })
+
+test('Escape dismisses the editor hover', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.cancelSelection',
+    key: KeyCode.Escape,
+    when: FocusKey.FocusEditorHover,
+  })
+})


### PR DESCRIPTION
## Summary

- route Escape from the editor-hover focus context through the editor cancellation command
- remove the hover before collapsing any active text selection
- advance the widget revision so stale asynchronous hover work cannot reopen it
- extend diagnostic-hover coverage through dismissal and reopen

## Validation

- 635 unit tests pass (53 skipped)
- focused diagnostic-hover e2e passes
- type checks pass
- lint, Prettier, and knip pass
- production and static builds pass
- bundled worker memory: 888,544 / 889,000 bytes; minified: 859,372 bytes