### PR TITLE
fix: persist editor undo history

### DIFF
--- a/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/editor-worker/src/parts/LoadContent/LoadContent.ts
@@ -32,6 +32,23 @@ const getErrorMessage = (error: unknown): string => {
   return String(error)
 }
 
+const getSavedHistory = (
+  savedState: unknown,
+  content: string,
+): { readonly redoStack: readonly any[]; readonly undoStack: readonly any[] } | undefined => {
+  if (!savedState || typeof savedState !== 'object') {
+    return undefined
+  }
+  const { lines, redoStack, undoStack } = savedState as Record<string, unknown>
+  if (!Array.isArray(lines) || lines.some((line) => typeof line !== 'string') || lines.join('\n') !== content) {
+    return undefined
+  }
+  if (!Array.isArray(redoStack) || !Array.isArray(undoStack)) {
+    return undefined
+  }
+  return { redoStack, undoStack }
+}
+
 export const loadContent = async (state: EditorState, savedState: unknown) => {
   const { assetDir, height, id, platform, uri, width, x, y } = state
   const {
@@ -107,6 +124,8 @@ export const loadContent = async (state: EditorState, savedState: unknown) => {
     }
   }
 
+  const savedHistory = existingEditor ? undefined : getSavedHistory(savedState, content)
+
   // TODO avoid creating intermediate editors here
   const newEditor1 = Editor.setBounds(newEditor0, x, y, width, height, 9)
   const newEditor2 = Editor.setText(newEditor1, content)
@@ -136,8 +155,8 @@ export const loadContent = async (state: EditorState, savedState: unknown) => {
     completionsOnType,
     initial: false,
     modified: existingEditor?.modified || false,
-    redoStack: existingEditor?.redoStack || [],
-    undoStack: existingEditor?.undoStack || [],
+    redoStack: existingEditor?.redoStack || savedHistory?.redoStack || [],
+    undoStack: existingEditor?.undoStack || savedHistory?.undoStack || [],
   }
   return newEditor5
 }

--- a/packages/editor-worker/src/parts/SaveState/SaveState.ts
+++ b/packages/editor-worker/src/parts/SaveState/SaveState.ts
@@ -1,8 +1,10 @@
 import type { EditorState } from '../State/State.ts'
 
 export const saveState = (state: EditorState, savedState: unknown): any => {
-  const { lines } = state
+  const { lines, redoStack, undoStack } = state
   return {
     lines,
+    redoStack,
+    undoStack,
   }
 }

--- a/packages/editor-worker/test/LoadContent.test.ts
+++ b/packages/editor-worker/test/LoadContent.test.ts
@@ -212,3 +212,44 @@ test('loadContent reuses unsaved content from another editor for the same uri', 
   expect(result.undoStack).toBe(existingEditor.undoStack)
   expect(readFileMock).not.toHaveBeenCalled()
 })
+
+test('loadContent restores saved history when the file content is unchanged', async () => {
+  readFileMock.mockResolvedValue('saved content')
+  const redoStack = [['redo']]
+  const undoStack = [['undo']]
+
+  const result = await LoadContent.loadContent(createState(), {
+    lines: ['saved content'],
+    redoStack,
+    undoStack,
+  })
+
+  expect(result.redoStack).toBe(redoStack)
+  expect(result.undoStack).toBe(undoStack)
+})
+
+test('loadContent discards saved history when the file content changed', async () => {
+  readFileMock.mockResolvedValue('changed externally')
+
+  const result = await LoadContent.loadContent(createState(), {
+    lines: ['saved content'],
+    redoStack: [['redo']],
+    undoStack: [['undo']],
+  })
+
+  expect(result.redoStack).toEqual([])
+  expect(result.undoStack).toEqual([])
+})
+
+test('loadContent ignores malformed saved history', async () => {
+  readFileMock.mockResolvedValue('saved content')
+
+  const result = await LoadContent.loadContent(createState(), {
+    lines: ['saved content'],
+    redoStack: {},
+    undoStack: [['undo']],
+  })
+
+  expect(result.redoStack).toEqual([])
+  expect(result.undoStack).toEqual([])
+})

--- a/packages/editor-worker/test/SaveState.test.ts
+++ b/packages/editor-worker/test/SaveState.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import { saveState } from '../src/parts/SaveState/SaveState.ts'
+
+test('saveState preserves document history', () => {
+  const lines = ['first line', 'second line']
+  const redoStack = [['redo change']]
+  const undoStack = [['undo change']]
+
+  expect(saveState({ lines, redoStack, undoStack } as any, undefined)).toEqual({
+    lines,
+    redoStack,
+    undoStack,
+  })
+})


### PR DESCRIPTION
## Summary

- serialize undo and redo stacks with editor state
- restore history only when the current file content exactly matches the saved lines
- keep existing same-URI editor synchronization as the highest-priority source

## Validation

- 193 test suites passed (639 tests; 9 suites and 53 tests skipped)
- TypeScript build passed
- focused ESLint passed
- source-built Electron UI validated close/reopen and cross-process restoration together with lvce-editor changes