### PR TITLE
fix: add editor redo shortcuts

### DIFF
--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -303,6 +303,16 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusEditorText,
     },
     {
+      command: 'Editor.redo',
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyZ,
+      when: WhenExpression.FocusEditorText,
+    },
+    {
+      command: 'Editor.redo',
+      key: KeyModifier.CtrlCmd | KeyCode.KeyY,
+      when: WhenExpression.FocusEditorText,
+    },
+    {
       command: 'Editor.cursorLeft',
       key: KeyCode.LeftArrow,
       when: WhenExpression.FocusEditorText,

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -118,6 +118,23 @@ test('Ctrl/Cmd+Alt+Down adds a cursor below', () => {
   })
 })
 
+test('Ctrl/Cmd+Shift+Z and Ctrl/Cmd+Y redo the last edit', () => {
+  expect(GetKeyBindings.getKeyBindings()).toEqual(
+    expect.arrayContaining([
+      {
+        command: 'Editor.redo',
+        key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyZ,
+        when: WhenExpression.FocusEditorText,
+      },
+      {
+        command: 'Editor.redo',
+        key: KeyModifier.CtrlCmd | KeyCode.KeyY,
+        when: WhenExpression.FocusEditorText,
+      },
+    ]),
+  )
+})
+
 test('Ctrl/Cmd+Shift+K deletes the active line', () => {
   expect(GetKeyBindings.getKeyBindings()).toContainEqual({
     command: 'Editor.deleteLine',


### PR DESCRIPTION
## Summary

- bind Ctrl/Cmd+Shift+Z to the existing Editor.redo command
- bind Ctrl/Cmd+Y as the alternate redo shortcut
- cover both keybindings in the editor-worker regression suite

## Validation

- 193 test suites passed (640 tests; 9 suites and 53 tests skipped)
- TypeScript and focused ESLint passed
- source-built Electron UI verified both shortcuts restore a single-character edit after Undo