### PR TITLE
fix: add undo commands to command palette

### DIFF
--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -34,6 +34,7 @@ import * as CursorEnd from '../EditorCommand/EditorCommandCursorEnd.ts'
 import * as CursorHome from '../EditorCommand/EditorCommandCursorHome.ts'
 import { cursorPageDown } from '../EditorCommand/EditorCommandCursorPageDown.ts'
 import * as EditorCursorSet from '../EditorCommand/EditorCommandCursorSet.ts'
+import * as CursorUndo from '../EditorCommand/EditorCommandCursorUndo.ts'
 import * as CursorUp from '../EditorCommand/EditorCommandCursorUp.ts'
 import * as CursorWordLeft from '../EditorCommand/EditorCommandCursorWordLeft.ts'
 import * as CursorWordPartLeft from '../EditorCommand/EditorCommandCursorWordPartLeft.ts'
@@ -227,6 +228,7 @@ export const commandMap = {
   'Editor.cursorPageDown': wrapCommand(cursorPageDown),
   'Editor.cursorRight': wrapCommand(CursorCharacterRight.cursorCharacterRight),
   'Editor.cursorSet': wrapCommand(EditorCursorSet.cursorSet),
+  'Editor.cursorUndo': wrapCommand(CursorUndo.cursorUndo),
   'Editor.cursorUp': wrapCommand(CursorUp.cursorUp),
   'Editor.cursorWordLeft': wrapCommand(CursorWordLeft.cursorWordLeft),
   'Editor.cursorWordPartLeft': wrapCommand(CursorWordPartLeft.cursorWordPartLeft),

--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorUndo.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorUndo.ts
@@ -1,0 +1,5 @@
+import type { EditorState } from '../State/State.ts'
+
+export const cursorUndo = (editor: EditorState): EditorState => {
+  return editor
+}

--- a/packages/editor-worker/src/parts/EditorStrings/EditorStrings.ts
+++ b/packages/editor-worker/src/parts/EditorStrings/EditorStrings.ts
@@ -89,6 +89,10 @@ export const paste = () => {
   return I18nString.i18nString(UiStrings.Paste)
 }
 
+export const cursorUndo = () => {
+  return I18nString.i18nString(UiStrings.CursorUndo)
+}
+
 export const undo = () => {
   return I18nString.i18nString(UiStrings.Undo)
 }

--- a/packages/editor-worker/src/parts/GetQuickPickMenuEntries/GetQuickPickMenuEntries.ts
+++ b/packages/editor-worker/src/parts/GetQuickPickMenuEntries/GetQuickPickMenuEntries.ts
@@ -4,6 +4,18 @@ import * as EditorStrings from '../EditorStrings/EditorStrings.ts'
 export const getQuickPickMenuEntries = (): readonly QuickPickMenuEntry[] => {
   return [
     {
+      id: 'Editor.undo',
+      label: EditorStrings.undo(),
+    },
+    {
+      id: 'Editor.redo',
+      label: EditorStrings.redo(),
+    },
+    {
+      id: 'Editor.cursorUndo',
+      label: EditorStrings.cursorUndo(),
+    },
+    {
       id: 'Editor.fold',
       label: EditorStrings.fold(),
     },

--- a/packages/editor-worker/src/parts/UiStrings/UiStrings.ts
+++ b/packages/editor-worker/src/parts/UiStrings/UiStrings.ts
@@ -1,6 +1,7 @@
 export const Copy = 'Copy'
 export const CopyLineDown = 'Copy Line Down'
 export const CopyLineUp = 'Copy Line Up'
+export const CursorUndo = 'Cursor Undo'
 export const Cut = 'Cut'
 export const DeleteLine = 'Delete Line'
 export const DuplicateSelection = 'Duplicate Selection'

--- a/packages/editor-worker/test/EditorCommandCursorUndo.test.ts
+++ b/packages/editor-worker/test/EditorCommandCursorUndo.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals'
+import { cursorUndo } from '../src/parts/EditorCommand/EditorCommandCursorUndo.ts'
+
+test('returns the editor unchanged until cursor history is available', () => {
+  const editor = {
+    selections: new Uint32Array([0, 0, 0, 0]),
+  }
+
+  expect(cursorUndo(editor as any)).toBe(editor)
+})

--- a/packages/editor-worker/test/GetQuickPickMenuEntries.test.ts
+++ b/packages/editor-worker/test/GetQuickPickMenuEntries.test.ts
@@ -29,3 +29,22 @@ test('includes folding commands', () => {
     ]),
   )
 })
+
+test('includes undo commands', () => {
+  expect(getQuickPickMenuEntries()).toEqual(
+    expect.arrayContaining([
+      {
+        id: 'Editor.undo',
+        label: 'Undo',
+      },
+      {
+        id: 'Editor.redo',
+        label: 'Redo',
+      },
+      {
+        id: 'Editor.cursorUndo',
+        label: 'Cursor Undo',
+      },
+    ]),
+  )
+})


### PR DESCRIPTION
## Summary
- expose Undo, Redo, and Cursor Undo in the editor command palette
- register a behavior-neutral Cursor Undo endpoint ahead of cursor-history support
- cover palette contributions and the placeholder endpoint with tests

## Validation
- 194 test suites, 646 tests passed
- type-check, lint, formatting, build, and memory measurement passed
- source-built Electron UI verified all three searches plus Undo/Redo invocation