### PR TITLE
Fix cursor and selection undo

### DIFF
--- a/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorUndo.ts
+++ b/packages/editor-worker/src/parts/EditorCommand/EditorCommandCursorUndo.ts
@@ -1,5 +1,15 @@
 import type { EditorState } from '../State/State.ts'
+import * as Editor from '../Editor/Editor.ts'
 
 export const cursorUndo = (editor: EditorState): EditorState => {
-  return editor
+  const { cursorUndoStack = [] } = editor
+  if (cursorUndoStack.length === 0) {
+    return editor
+  }
+  const selections = cursorUndoStack.at(-1)!
+  const newEditor = {
+    ...editor,
+    cursorUndoStack: cursorUndoStack.slice(0, -1),
+  }
+  return Editor.scheduleSelections(newEditor, selections)
 }

--- a/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/editor-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -303,6 +303,11 @@ export const getKeyBindings = () => {
       when: WhenExpression.FocusEditorText,
     },
     {
+      command: 'Editor.cursorUndo',
+      key: KeyModifier.CtrlCmd | KeyCode.KeyU,
+      when: WhenExpression.FocusEditorText,
+    },
+    {
       command: 'Editor.redo',
       key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyZ,
       when: WhenExpression.FocusEditorText,

--- a/packages/editor-worker/src/parts/State/State.ts
+++ b/packages/editor-worker/src/parts/State/State.ts
@@ -10,6 +10,7 @@ export interface EditorState {
   readonly completionTriggerCharacters: readonly string[]
   readonly completionUid: number
   readonly cursorInfos: readonly any[]
+  readonly cursorUndoStack?: readonly Uint32Array[]
   readonly cursorWidth: number
   readonly debugEnabled: boolean
   readonly decorations: any // Text-level decorations (flat array) for CSS classes like Link, Type, etc.

--- a/packages/editor-worker/src/parts/WrapCommands/WrapCommands.ts
+++ b/packages/editor-worker/src/parts/WrapCommands/WrapCommands.ts
@@ -9,6 +9,22 @@ import * as Preferences from '../Preferences/Preferences.ts'
 import * as UpdateDerivedState from '../UpdateDerivedState/UpdateDerivedState.ts'
 
 const queues: Record<string, Promise<void> | undefined> = {}
+const cursorUndoLimit = 100
+
+const selectionsEqual = (left: Uint32Array, right: Uint32Array): boolean => {
+  if (left === right) {
+    return true
+  }
+  if (left.length !== right.length) {
+    return false
+  }
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) {
+      return false
+    }
+  }
+  return true
+}
 
 const saveAfterDelay = async (uid: number, token: number): Promise<void> => {
   if (!Editors.get(uid)) {
@@ -52,8 +68,24 @@ export const wrapCommand =
     try {
       const oldInstance = Editors.get(uid)
       const state = oldInstance.newState
+      const { cursorUndoStack, initial, isSelecting, lines, modified, redoStack, selections, undoStack, uri } = state
       const commandResult = await fn(state, ...args)
-      const newEditor = !preservesTypingCoalescing && commandResult.canCoalesceTyping ? { ...commandResult, canCoalesceTyping: false } : commandResult
+      let newEditor = !preservesTypingCoalescing && commandResult.canCoalesceTyping ? { ...commandResult, canCoalesceTyping: false } : commandResult
+      if (lines !== newEditor.lines && newEditor.cursorUndoStack?.length) {
+        newEditor = { ...newEditor, cursorUndoStack: [] }
+      } else if (
+        selections &&
+        newEditor.selections &&
+        !isSelecting &&
+        newEditor.cursorUndoStack === cursorUndoStack &&
+        (!selectionsEqual(selections, newEditor.selections) || newEditor.isSelecting)
+      ) {
+        const previousCursorUndoStack = cursorUndoStack || []
+        newEditor = {
+          ...newEditor,
+          cursorUndoStack: [...previousCursorUndoStack.slice(1 - cursorUndoLimit), new Uint32Array(selections)],
+        }
+      }
       if (state === newEditor) {
         return newEditor
       }
@@ -67,7 +99,6 @@ export const wrapCommand =
         }
         Editors.set(uid, state, finalEditor)
       }
-      const { initial, lines, modified, redoStack, undoStack, uri } = state
       if (
         !initial &&
         uri === finalEditor.uri &&

--- a/packages/editor-worker/test/EditorCommandCursorUndo.test.ts
+++ b/packages/editor-worker/test/EditorCommandCursorUndo.test.ts
@@ -1,10 +1,27 @@
 import { expect, test } from '@jest/globals'
 import { cursorUndo } from '../src/parts/EditorCommand/EditorCommandCursorUndo.ts'
 
-test('returns the editor unchanged until cursor history is available', () => {
+test('returns the editor unchanged when cursor history is empty', () => {
   const editor = {
     selections: new Uint32Array([0, 0, 0, 0]),
   }
 
   expect(cursorUndo(editor as any)).toBe(editor)
+})
+
+test('restores cursor history entries in reverse order', () => {
+  const firstSelections = new Uint32Array([0, 0, 0, 0])
+  const secondSelections = new Uint32Array([0, 2, 0, 2])
+  const editor = {
+    cursorUndoStack: [firstSelections, secondSelections],
+    selections: new Uint32Array([0, 4, 0, 4]),
+  }
+
+  const firstResult = cursorUndo(editor as any)
+  const secondResult = cursorUndo(firstResult)
+
+  expect(firstResult.selections).toBe(secondSelections)
+  expect(firstResult.cursorUndoStack).toEqual([firstSelections])
+  expect(secondResult.selections).toBe(firstSelections)
+  expect(secondResult.cursorUndoStack).toEqual([])
 })

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -135,6 +135,14 @@ test('Ctrl/Cmd+Shift+Z and Ctrl/Cmd+Y redo the last edit', () => {
   )
 })
 
+test('Ctrl/Cmd+U restores the last cursor operation', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.cursorUndo',
+    key: KeyModifier.CtrlCmd | KeyCode.KeyU,
+    when: WhenExpression.FocusEditorText,
+  })
+})
+
 test('Ctrl/Cmd+Shift+K deletes the active line', () => {
   expect(GetKeyBindings.getKeyBindings()).toContainEqual({
     command: 'Editor.deleteLine',

--- a/packages/editor-worker/test/WrapCommands.test.ts
+++ b/packages/editor-worker/test/WrapCommands.test.ts
@@ -188,6 +188,105 @@ test('preserves typing coalescing for typing commands', async () => {
   expect(result.canCoalesceTyping).toBe(true)
 })
 
+test('records cursor and selection changes', async () => {
+  const selections = new Uint32Array([0, 0, 0, 0])
+  const state = {
+    initial: false,
+    isSelecting: false,
+    lines: ['abc'],
+    modified: false,
+    redoStack: [],
+    selections,
+    uid: 1,
+    undoStack: [],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    selections: new Uint32Array([0, 1, 0, 1]),
+  }))
+
+  const result = await command(1)
+
+  expect(result.cursorUndoStack).toEqual([selections])
+  expect(result.cursorUndoStack[0]).not.toBe(selections)
+})
+
+test('groups pointer-drag selection changes', async () => {
+  const previousSelections = new Uint32Array([0, 0, 0, 0])
+  const state = {
+    cursorUndoStack: [previousSelections],
+    initial: false,
+    isSelecting: true,
+    lines: ['abc'],
+    modified: false,
+    redoStack: [],
+    selections: new Uint32Array([0, 0, 0, 1]),
+    uid: 1,
+    undoStack: [],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    selections: new Uint32Array([0, 0, 0, 2]),
+  }))
+
+  const result = await command(1)
+
+  expect(result.cursorUndoStack).toEqual([previousSelections])
+})
+
+test('records a pointer drag that starts at the current cursor', async () => {
+  const selections = new Uint32Array([0, 0, 0, 0])
+  const state = {
+    initial: false,
+    isSelecting: false,
+    lines: ['abc'],
+    modified: false,
+    redoStack: [],
+    selections,
+    uid: 1,
+    undoStack: [],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    isSelecting: true,
+  }))
+
+  const result = await command(1)
+
+  expect(result.cursorUndoStack).toEqual([selections])
+})
+
+test('clears cursor history after a document edit', async () => {
+  const state = {
+    cursorUndoStack: [new Uint32Array([0, 0, 0, 0])],
+    initial: false,
+    isSelecting: false,
+    lines: ['abc'],
+    modified: false,
+    redoStack: [],
+    selections: new Uint32Array([0, 3, 0, 3]),
+    uid: 1,
+    undoStack: [],
+    uri: 'file:///one.txt',
+  }
+  EditorStates.set(1, state as any, state as any)
+  const command = WrapCommands.wrapCommand((editor: any) => ({
+    ...editor,
+    lines: ['abcd'],
+    selections: new Uint32Array([0, 4, 0, 4]),
+  }))
+
+  const result = await command(1)
+
+  expect(result.cursorUndoStack).toEqual([])
+})
+
 test('synchronizes document state with another editor showing the same uri', async () => {
   const firstState = {
     decorations: [],


### PR DESCRIPTION
## Summary

- track bounded cursor and selection history for selection-only editor commands
- implement Editor.cursorUndo and bind Ctrl/Cmd+U
- group pointer drags, preserve history across focus changes, and clear stale history after document edits

## Validation

- 194 test suites passed, 652 tests passed
- lint, formatting, Knip, TypeScript, production build, and static build passed
- bundled worker memory: 890,048 bytes (limit: 891,000)
- minified worker memory: 860,648 bytes
- real Electron validation passed for word movement, repeated unwind, keyboard selection, mouse selection, focus round-trip, and empty history