### PR TITLE
Fix native typing undo coalescing

### DIFF
--- a/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/editor-worker/src/parts/CommandMap/CommandMap.ts
@@ -279,7 +279,7 @@ export const commandMap = {
   'Editor.getWordBefore2': ExternalGetPositionAtCursor.getWordBefore2,
   'Editor.goToDefinition': wrapCommand(EditorGoToDefinition.goToDefinition),
   'Editor.goToTypeDefinition': wrapCommand(EditorGoToTypeDefinition.goToTypeDefinition),
-  'Editor.handleBeforeInput': wrapCommand(HandleBeforeInput.handleBeforeInput),
+  'Editor.handleBeforeInput': wrapCommand(HandleBeforeInput.handleBeforeInput, true),
   'Editor.handleBeforeInputFromContentEditable': wrapCommand(
     EditorCommandHandleNativeBeforeInputFromContentEditable.handleBeforeInputFromContentEditable,
   ),
@@ -288,7 +288,7 @@ export const commandMap = {
   'Editor.handleContextMenu': wrapCommand(EditorCommandHandleContextMenu.handleContextMenu),
   'Editor.handleDoubleClick': wrapCommand(HandleDoubleClick.handleDoubleClick),
   'Editor.handleFocus': wrapCommand(HandleFocus.handleFocus),
-  'Editor.handleKeyUp': wrapCommand(HandleKeyUp.handleKeyUp),
+  'Editor.handleKeyUp': wrapCommand(HandleKeyUp.handleKeyUp, true),
   'Editor.handleMouseDown': wrapCommand(HandleMouseDown.handleMouseDown),
   'Editor.handleMouseMove': wrapCommand(HandleMouseMove.handleMouseMove),
   'Editor.handleMouseMoveWithAltKey': wrapCommand(EditorCommandHandleMouseMoveWithAltKey.handleMouseMoveWithAltKey),

--- a/packages/editor-worker/test/EditorCommandUndo.test.ts
+++ b/packages/editor-worker/test/EditorCommandUndo.test.ts
@@ -17,9 +17,11 @@ SyntaxHighlightingWorker.set(
   }),
 )
 
+import { commandMap } from '../src/parts/CommandMap/CommandMap.ts'
 import * as Editor from '../src/parts/Editor/Editor.ts'
 import * as EditorCommandUndo from '../src/parts/EditorCommand/EditorCommandUndo.ts'
 import * as EditOrigin from '../src/parts/EditOrigin/EditOrigin.ts'
+import * as EditorStates from '../src/parts/EditorStates/EditorStates.ts'
 import { emptyEditor } from '../src/parts/EmptyEditor/EmptyEditor.ts'
 
 const createChange = (text: string, columnIndex: number) => ({
@@ -111,6 +113,33 @@ test('schedule document edits - coalesces contiguous typing', async () => {
   editor = await Editor.scheduleDocumentAndCursorsSelections(editor, [createChange('b', 1)])
 
   expect(editor.undoStack).toEqual([[{ ...createChange('a', 0), inserted: ['ab'] }]])
+})
+
+test('beforeinput coalesces contiguous typing into one undo', async () => {
+  const uid = 1
+  const editor = {
+    ...emptyEditor,
+    initial: false,
+    invalidStartIndex: 0,
+    lines: [''],
+    modified: false,
+    numberOfVisibleLines: 32,
+    selections: new Uint32Array([0, 0, 0, 0]),
+    uid,
+    uri: 'file:///test.txt',
+  }
+  EditorStates.set(uid, editor, editor)
+
+  await commandMap['Editor.handleBeforeInput'](uid, 'insertText', 'a')
+  await commandMap['Editor.handleKeyUp'](uid, 'a')
+  await commandMap['Editor.handleBeforeInput'](uid, 'insertText', 'b')
+  await commandMap['Editor.handleKeyUp'](uid, 'b')
+  await commandMap['Editor.handleBeforeInput'](uid, 'insertText', 'c')
+  await commandMap['Editor.handleKeyUp'](uid, 'c')
+  await commandMap['Editor.undo'](uid)
+
+  expect(EditorStates.get(uid).newState.lines).toEqual([''])
+  EditorStates.dispose(uid)
 })
 
 test('undo - deleted character', async () => {


### PR DESCRIPTION
## Summary
- preserve typing coalescing across the real `beforeinput` command path
- keep ordinary key-up events from clearing the coalescing state after every typed character
- cover native `beforeinput` plus key-up sequencing with one-Undo regression coverage

## Validation
- 194 test suites passed; 653 tests passed; 9 suites / 53 tests skipped
- full lint, formatting, type-check, build, and static build passed
- worker memory: 890,060 bytes bundled and 860,660 bytes minified (threshold 891,000)
- source Electron UI with native X11 typing: `abc` is removed by one Undo; Redo restores it; cursor movement creates a new undo boundary

This is the final-acceptance follow-up for the contiguous typing finding from the editor undo / cursor undo / selection undo test-and-fix run.