### PR TITLE
fix: indent selected text with tab

### DIFF
--- a/packages/e2e/src/editor.handle-tab-indent-selection.ts
+++ b/packages/e2e/src/editor.handle-tab-indent-selection.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.editor-handle-tab-indent-selection'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'one\ntwo\nthree')

--- a/packages/editor-worker/src/parts/HandleTab/HandleTab.ts
+++ b/packages/editor-worker/src/parts/HandleTab/HandleTab.ts
@@ -1,7 +1,12 @@
 import * as ApplyTabCompletion from '../ApplyTabCompletion/ApplyTabCompletion.ts'
+import * as EditorIndentMore from '../EditorCommand/EditorCommandIndentMore.ts'
+import * as EditorSelection from '../EditorSelection/EditorSelection.ts'
 import * as TabCompletion from '../TabCompletion/TabCompletion.ts'
 
 export const handleTab = async (editor: any) => {
+  if (!EditorSelection.isEverySelectionEmpty(editor.selections)) {
+    return EditorIndentMore.indentMore(editor)
+  }
   const result = await TabCompletion.getTabCompletion(editor)
   if (!result) {
     // TODO enter tab or two spaces

--- a/packages/editor-worker/test/HandleTab.test.ts
+++ b/packages/editor-worker/test/HandleTab.test.ts
@@ -14,6 +14,25 @@ RendererWorker.set(mockRpc)
 const HandleTab = await import('../src/parts/HandleTab/HandleTab.ts')
 const TabCompletion = await import('../src/parts/TabCompletion/TabCompletion.ts')
 
+test('handleTab - indent selection', async () => {
+  const editor = {
+    decorations: [],
+    invalidStartIndex: 0,
+    lineCache: [],
+    lines: ['one', 'two', 'three'],
+    minLineY: 0,
+    modified: true,
+    numberOfVisibleLines: 32,
+    primarySelectionIndex: 0,
+    selections: new Uint32Array([0, 1, 1, 2]),
+    undoStack: [],
+  }
+
+  expect(await HandleTab.handleTab(editor)).toMatchObject({
+    lines: ['  one', '  two', 'three'],
+  })
+})
+
 test.skip('handleTab - no result', async () => {
   // Skipped: Cannot spy on ES module exports (read-only properties)
   const getTabCompletionSpy = jest.spyOn(TabCompletion, 'getTabCompletion').mockResolvedValue(undefined)


### PR DESCRIPTION
Fix Tab handling so a non-empty editor selection indents all selected lines before tab-completion lookup. Enables the existing end-to-end regression for indenting a selected block.