### PR TITLE
fix: move editor lines up and down

### DIFF
--- a/packages/e2e/src/editor.move-line-shortcuts.ts
+++ b/packages/e2e/src/editor.move-line-shortcuts.ts
@@ -1,6 +1,6 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'viewlet.editor-move-line-down-command'
+export const name = 'editor.move-line-shortcuts'
 
 export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
@@ -9,8 +9,15 @@ export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace 
   await Main.openUri(`${tmpDir}/file1.txt`)
   await Editor.setCursor(0, 0)
 
-  await Command.execute('Editor.moveLineDown')
-
+  const downArrow = 16
+  const upArrow = 14
+  const shift = 1 << 10
+  const control = 1 << 11
+  await Command.execute('KeyBindings.handleKeyBinding', control | shift | downArrow)
   await Editor.shouldHaveText('two\none\nthree')
   await Editor.shouldHaveSelections(new Uint32Array([1, 0, 1, 0]))
+
+  await Command.execute('KeyBindings.handleKeyBinding', control | shift | upArrow)
+  await Editor.shouldHaveText('one\ntwo\nthree')
+  await Editor.shouldHaveSelections(new Uint32Array([0, 0, 0, 0]))
 }

--- a/packages/e2e/src/editor.move-line-up-command.ts
+++ b/packages/e2e/src/editor.move-line-up-command.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.editor-move-line-up-command'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'one\ntwo\nthree')

--- a/packages/e2e/src/editor.undo-redo-move-line-down.ts
+++ b/packages/e2e/src/editor.undo-redo-move-line-down.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.editor-undo-redo-move-line-down'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'one\ntwo\nthree')
@@ -12,8 +10,8 @@ export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace 
   await Editor.setCursor(0, 0)
   await Command.execute('Editor.moveLineDown')
 
-  await Editor.undo()
-  await Editor.redo()
+  await Command.execute('Editor.undo')
+  await Command.execute('Editor.redo')
 
   await Editor.shouldHaveText('two\none\nthree')
 }

--- a/packages/e2e/src/editor.undo-redo-move-line-up.ts
+++ b/packages/e2e/src/editor.undo-redo-move-line-up.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.editor-undo-redo-move-line-up'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'one\ntwo\nthree')
@@ -12,8 +10,8 @@ export const test: Test = async ({ Command, Editor, FileSystem, Main, Workspace 
   await Editor.setCursor(2, 0)
   await Command.execute('Editor.moveLineUp')
 
-  await Editor.undo()
-  await Editor.redo()
+  await Command.execute('Editor.undo')
+  await Command.execute('Editor.redo')
 
   await Editor.shouldHaveText('one\nthree\ntwo')
 }

--- a/packages/editor-worker/src/parts/MoveLineDown/MoveLineDown.ts
+++ b/packages/editor-worker/src/parts/MoveLineDown/MoveLineDown.ts
@@ -1,27 +1,5 @@
-// TODO move cursor
-// TODO multiple cursors -> VS Code removes multiple cursors
-// TODO with selection -> VS Code moves whole selection
+import * as MoveLines from '../MoveLines/MoveLines.ts'
+
 export const moveLineDown = (editor: any) => {
-  // const rowIndex = editor.cursor.rowIndex
-  // if (rowIndex === editor.lines.length - 1) {
-  //   return
-  // }
-  // const documentEdits = [
-  //   {
-  //     type: /* splice */ 2,
-  //     rowIndex: rowIndex,
-  //     count: 2,
-  //     newLines: [TextDocument.getLine(editor.textDocument, rowIndex + 1), TextDocument.getLine(editor.textDocument, rowIndex)],
-  //   },
-  // ]
-  // // @ts-ignore
-  // const cursorEdits = Editor.moveCursors(editor, (editor, cursor) => {
-  //   return {
-  //     rowIndex: cursor.rowIndex + 1,
-  //     columnIndex: cursor.columnIndex,
-  //   }
-  // })
-  // @ts-ignore
-  // Editor.scheduleDocumentAndCursors(editor, documentEdits, cursorEdits)
-  return editor
+  return MoveLines.moveLines(editor, 1)
 }

--- a/packages/editor-worker/src/parts/MoveLineUp/MoveLineUp.ts
+++ b/packages/editor-worker/src/parts/MoveLineUp/MoveLineUp.ts
@@ -1,26 +1,5 @@
-// TODO handle multiple cursors
+import * as MoveLines from '../MoveLines/MoveLines.ts'
+
 export const moveLineUp = (editor: any) => {
-  // const rowIndex = editor.cursor.rowIndex
-  // if (rowIndex === 0) {
-  //   return
-  // }
-  // const documentEdits = [
-  //   {
-  //     type: /* splice */ 2,
-  //     rowIndex: rowIndex - 1,
-  //     count: 2,
-  //     newLines: [TextDocument.getLine(editor.textDocument, rowIndex), TextDocument.getLine(editor.textDocument, rowIndex - 1)],
-  //   },
-  // ]
-  // // @ts-ignore
-  // const cursorEdits = Editor.moveCursors(editor, (editor, cursor) => {
-  //   return {
-  //     // TODO handle bottom 0
-  //     rowIndex: cursor.rowIndex - 1,
-  //     columnIndex: cursor.columnIndex,
-  //   }
-  // })
-  // // @ts-ignore
-  // Editor.scheduleDocumentAndCursors(editor, documentEdits, cursorEdits)
-  return editor
+  return MoveLines.moveLines(editor, -1)
 }

--- a/packages/editor-worker/src/parts/MoveLines/MoveLines.ts
+++ b/packages/editor-worker/src/parts/MoveLines/MoveLines.ts
@@ -1,0 +1,64 @@
+import * as Editor from '../Editor/Editor.ts'
+import * as EditOrigin from '../EditOrigin/EditOrigin.ts'
+import * as GetSelectionPairs from '../GetSelectionPairs/GetSelectionPairs.ts'
+
+const getSelectedLineRange = (selections: Uint32Array, primarySelectionIndex: number) => {
+  const [startRowIndex, , selectionEndRowIndex, endColumnIndex] = GetSelectionPairs.getSelectionPairs(selections, primarySelectionIndex)
+  const endRowIndex = startRowIndex < selectionEndRowIndex && endColumnIndex === 0 ? selectionEndRowIndex - 1 : selectionEndRowIndex
+  return {
+    endRowIndex,
+    startRowIndex,
+  }
+}
+
+const movePositionDown = (lines: readonly string[], rowIndex: number, columnIndex: number): readonly [number, number] => {
+  const newRowIndex = rowIndex + 1
+  if (newRowIndex < lines.length) {
+    return [newRowIndex, columnIndex]
+  }
+  const lastRowIndex = lines.length - 1
+  return [lastRowIndex, lines[rowIndex - 1].length]
+}
+
+const getSelectionChanges = (lines: readonly string[], selections: Uint32Array, primarySelectionIndex: number, direction: number): Uint32Array => {
+  const startRowIndex = selections[primarySelectionIndex]
+  const startColumnIndex = selections[primarySelectionIndex + 1]
+  const endRowIndex = selections[primarySelectionIndex + 2]
+  const endColumnIndex = selections[primarySelectionIndex + 3]
+  if (direction < 0) {
+    return new Uint32Array([startRowIndex - 1, startColumnIndex, endRowIndex - 1, endColumnIndex])
+  }
+  const [newStartRowIndex, newStartColumnIndex] = movePositionDown(lines, startRowIndex, startColumnIndex)
+  const [newEndRowIndex, newEndColumnIndex] = movePositionDown(lines, endRowIndex, endColumnIndex)
+  return new Uint32Array([newStartRowIndex, newStartColumnIndex, newEndRowIndex, newEndColumnIndex])
+}
+
+export const moveLines = (editor: any, direction: number) => {
+  const { lines, primarySelectionIndex = 0, selections } = editor
+  const { endRowIndex, startRowIndex } = getSelectedLineRange(selections, primarySelectionIndex)
+  const lastRowIndex = lines.length - 1
+  if ((direction < 0 && startRowIndex === 0) || (direction > 0 && endRowIndex === lastRowIndex)) {
+    return editor
+  }
+  const editStartRowIndex = direction < 0 ? startRowIndex - 1 : startRowIndex
+  const editEndRowIndex = direction < 0 ? endRowIndex : endRowIndex + 1
+  const selectedLines = lines.slice(startRowIndex, endRowIndex + 1)
+  const inserted = direction < 0 ? [...selectedLines, lines[startRowIndex - 1]] : [lines[endRowIndex + 1], ...selectedLines]
+  const changes = [
+    {
+      deleted: lines.slice(editStartRowIndex, editEndRowIndex + 1),
+      end: {
+        columnIndex: lines[editEndRowIndex].length,
+        rowIndex: editEndRowIndex,
+      },
+      inserted,
+      origin: EditOrigin.Unknown,
+      start: {
+        columnIndex: 0,
+        rowIndex: editStartRowIndex,
+      },
+    },
+  ]
+  const selectionChanges = getSelectionChanges(lines, selections, primarySelectionIndex, direction)
+  return Editor.scheduleDocumentAndCursorsSelections(editor, changes, selectionChanges)
+}

--- a/packages/editor-worker/test/GetKeyBindings.test.ts
+++ b/packages/editor-worker/test/GetKeyBindings.test.ts
@@ -118,6 +118,22 @@ test('Ctrl/Cmd+Alt+Down adds a cursor below', () => {
   })
 })
 
+test('Ctrl/Cmd+Shift+Up moves lines up', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.moveLineUp',
+    key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.UpArrow,
+    when: WhenExpression.FocusEditorText,
+  })
+})
+
+test('Ctrl/Cmd+Shift+Down moves lines down', () => {
+  expect(GetKeyBindings.getKeyBindings()).toContainEqual({
+    command: 'Editor.moveLineDown',
+    key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.DownArrow,
+    when: WhenExpression.FocusEditorText,
+  })
+})
+
 test('Ctrl/Cmd+Shift+Z and Ctrl/Cmd+Y redo the last edit', () => {
   expect(GetKeyBindings.getKeyBindings()).toEqual(
     expect.arrayContaining([

--- a/packages/editor-worker/test/MoveLines.test.ts
+++ b/packages/editor-worker/test/MoveLines.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from '@jest/globals'
+import { MockRpc } from '@lvce-editor/rpc'
+import { ExtensionHost, RendererWorker } from '@lvce-editor/rpc-registry'
+
+const mockRpc = MockRpc.create({
+  commandMap: {},
+  invoke: async () => undefined,
+})
+ExtensionHost.set(mockRpc)
+RendererWorker.set(mockRpc)
+
+import * as EditorSelection from '../src/parts/EditorSelection/EditorSelection.ts'
+import * as MoveLineDown from '../src/parts/MoveLineDown/MoveLineDown.ts'
+import * as MoveLineUp from '../src/parts/MoveLineUp/MoveLineUp.ts'
+import * as TokenizePlainText from '../src/parts/TokenizePlainText/TokenizePlainText.ts'
+
+const createEditor = (selections: Uint32Array, lines = ['alpha', 'bravo', 'charlie', 'delta']) => ({
+  decorations: [],
+  invalidStartIndex: 0,
+  lineCache: [],
+  lines,
+  minLineY: 0,
+  numberOfVisibleLines: 32,
+  primarySelectionIndex: 0,
+  selections,
+  tokenizer: TokenizePlainText,
+  undoStack: [],
+})
+
+test('moveLineDown - moves the active line and cursor down', async () => {
+  const editor = createEditor(EditorSelection.fromRange(0, 2, 0, 2))
+
+  expect(await MoveLineDown.moveLineDown(editor)).toMatchObject({
+    lines: ['bravo', 'alpha', 'charlie', 'delta'],
+    selections: EditorSelection.fromRange(1, 2, 1, 2),
+  })
+})
+
+test('moveLineDown - last line is unchanged', () => {
+  const editor = createEditor(EditorSelection.fromRange(3, 2, 3, 2))
+
+  expect(MoveLineDown.moveLineDown(editor)).toBe(editor)
+})
+
+test('moveLineUp - moves the active line and cursor up', async () => {
+  const editor = createEditor(EditorSelection.fromRange(2, 3, 2, 3))
+
+  expect(await MoveLineUp.moveLineUp(editor)).toMatchObject({
+    lines: ['alpha', 'charlie', 'bravo', 'delta'],
+    selections: EditorSelection.fromRange(1, 3, 1, 3),
+  })
+})
+
+test('moveLineUp - first line is unchanged', () => {
+  const editor = createEditor(EditorSelection.fromRange(0, 2, 0, 2))
+
+  expect(MoveLineUp.moveLineUp(editor)).toBe(editor)
+})
+
+test('moveLineDown - moves a multi-line selection as a block', async () => {
+  const editor = createEditor(EditorSelection.fromRange(0, 1, 1, 3))
+
+  expect(await MoveLineDown.moveLineDown(editor)).toMatchObject({
+    lines: ['charlie', 'alpha', 'bravo', 'delta'],
+    selections: EditorSelection.fromRange(1, 1, 2, 3),
+  })
+})
+
+test('moveLineDown - excludes a selection end at the start of the following line', async () => {
+  const editor = createEditor(EditorSelection.fromRange(0, 2, 2, 0))
+
+  expect(await MoveLineDown.moveLineDown(editor)).toMatchObject({
+    lines: ['charlie', 'alpha', 'bravo', 'delta'],
+    selections: EditorSelection.fromRange(1, 2, 3, 0),
+  })
+})
+
+test('moveLineDown - keeps a full-line selection valid when moving to the end of the document', async () => {
+  const editor = createEditor(EditorSelection.fromRange(2, 0, 3, 0))
+
+  expect(await MoveLineDown.moveLineDown(editor)).toMatchObject({
+    lines: ['alpha', 'bravo', 'delta', 'charlie'],
+    selections: EditorSelection.fromRange(3, 0, 3, 7),
+  })
+})
+
+test('moveLineUp - preserves a reversed partial-line selection', async () => {
+  const editor = createEditor(EditorSelection.fromRange(2, 2, 1, 1))
+
+  expect(await MoveLineUp.moveLineUp(editor)).toMatchObject({
+    lines: ['bravo', 'charlie', 'alpha', 'delta'],
+    selections: EditorSelection.fromRange(1, 2, 0, 1),
+  })
+})
+
+test('moveLineDown - preserves blank and indented lines', async () => {
+  const editor = createEditor(EditorSelection.fromRange(0, 0, 0, 0), ['', '  indented', 'omega'])
+
+  expect(await MoveLineDown.moveLineDown(editor)).toMatchObject({
+    lines: ['  indented', '', 'omega'],
+    selections: EditorSelection.fromRange(1, 0, 1, 0),
+  })
+})
+
+test('moveLineDown - collapses multiple selections to the primary moved selection', async () => {
+  const editor = createEditor(new Uint32Array([0, 1, 0, 1, 2, 2, 2, 2]))
+
+  expect(await MoveLineDown.moveLineDown(editor)).toMatchObject({
+    lines: ['bravo', 'alpha', 'charlie', 'delta'],
+    selections: EditorSelection.fromRange(1, 1, 1, 1),
+  })
+})
+
+test('moveLineDown - moves the indexed primary selection', async () => {
+  const editor = {
+    ...createEditor(new Uint32Array([0, 1, 0, 1, 1, 2, 1, 2])),
+    primarySelectionIndex: 4,
+  }
+
+  expect(await MoveLineDown.moveLineDown(editor)).toMatchObject({
+    lines: ['alpha', 'charlie', 'bravo', 'delta'],
+    selections: EditorSelection.fromRange(2, 2, 2, 2),
+  })
+})


### PR DESCRIPTION
Restores Move Line Up and Move Line Down through the current editor edit pipeline, including selections, boundaries, undo/redo, and the default Ctrl+Shift+Up/Down shortcuts. Re-enables the existing move-line end-to-end coverage and adds focused shortcut and selection regressions.